### PR TITLE
fix: enable prerendering for SEO and resolve build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/d3-sankey": "^0.12.3",
         "@types/marked": "^5.0.2",
         "@types/mdast": "^4.0.4",
+        "@types/node": "^24.10.1",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@types/react-helmet": "^6.1.11",
@@ -2104,6 +2105,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
@@ -11897,6 +11908,13 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/d3-sankey": "^0.12.3",
     "@types/marked": "^5.0.2",
     "@types/mdast": "^4.0.4",
+    "@types/node": "^24.10.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/react-helmet": "^6.1.11",

--- a/src/components/L1MetricsChart.tsx
+++ b/src/components/L1MetricsChart.tsx
@@ -507,7 +507,6 @@ export function L1MetricsChart({ chainId, chainName, evmChainId, tokenSymbol }: 
         error={error}
         onRetry={() => handleTimeframeChange(timeframe)}
         valueFormatter={formatValue}
-        valueLabel={selectedMetric === 'tps' ? 'TPS' : ''}
         tooltipFormatter={tooltipFormatter}
         color={{
           line: 'rgb(239, 68, 68)', // Brand red #ef4444

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,103 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
-export default defineConfig({
-  plugins: [react()],
-  publicDir: 'public',
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          'chart-vendor': ['chart.js', 'react-chartjs-2'],
+const require = createRequire(import.meta.url);
+// @ts-ignore - vite-plugin-prerender doesn't have types and needs require
+const vitePrerender = require('vite-plugin-prerender');
+const Renderer = require('@prerenderer/renderer-puppeteer');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Helper to fetch blog routes
+async function getBlogRoutes(apiBaseUrl: string) {
+  try {
+    // Use fetch (available in Node 18+)
+    const response = await fetch(`${apiBaseUrl}/api/blog/posts?limit=1000`);
+    if (!response.ok) return [];
+    
+    const data: any = await response.json();
+    // Assuming the API returns { data: [{ slug: '...' }] }
+    if (data && Array.isArray(data.data)) {
+      return data.data.map((post: any) => `/blog/${post.slug}`);
+    }
+    return [];
+  } catch (e) {
+    console.warn('Warning: Could not fetch blog routes for prerendering. Blog SEO tags may not work.');
+    console.warn(e);
+    return [];
+  }
+}
+
+export default defineConfig(async ({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiBaseUrl = env.VITE_API_BASE_URL || 'https://l1beat-backend.onrender.com'; // Fallback if needed
+
+  // Define base routes
+  let routesToPrerender = ['/', '/blog', '/acps', '/404'];
+
+  // Only fetch dynamic routes during production build to save time
+  if (mode === 'production') {
+    console.log('Fetching blog routes for prerendering...');
+    const blogRoutes = await getBlogRoutes(apiBaseUrl);
+    console.log(`Found ${blogRoutes.length} blog posts to prerender.`);
+    routesToPrerender = [...routesToPrerender, ...blogRoutes];
+  }
+
+  return {
+    plugins: [
+      react(),
+      vitePrerender({
+        // The path to the directory where the build files are generated
+        staticDir: path.join(__dirname, 'dist'),
+        
+        // The list of routes to prerender
+        routes: routesToPrerender,
+
+        // The renderer to use (Puppeteer)
+        renderer: new Renderer({
+          // Wait for the element with id "root" to be rendered
+          renderAfterDocumentEvent: 'custom-render-trigger',
+          // OR simply wait for a specific amount of time (e.g., 5 seconds) for data to load
+          renderAfterTime: 5000, 
+          // Optional: Run headless
+          headless: true,
+        }),
+        
+        // Post-process the HTML to fix any paths or data
+        postProcess(renderedRoute: any) {
+          // Replace any localhost references with production URL if necessary
+          renderedRoute.html = renderedRoute.html.replace(
+            /http:\/\/localhost:\d+/g, 
+            'https://l1beat.com'
+          );
+          return renderedRoute;
+        },
+      }),
+    ],
+    publicDir: 'public',
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+            'chart-vendor': ['chart.js', 'react-chartjs-2'],
+          },
         },
       },
+      target: 'esnext',
+      minify: 'esbuild',
     },
-    target: 'esnext',
-    minify: 'esbuild',
-  },
-  server: {
-    headers: {
-      'Cache-Control': 'no-cache, no-store, must-revalidate',
-      'Pragma': 'no-cache',
-      'Expires': '0',
+    server: {
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+      },
     },
-  },
+  } as any; // Cast to any to avoid UserConfig type mismatch with vite-plugin-prerender
 });


### PR DESCRIPTION
- Update vite.config.ts to use vite-plugin-prerender for generating static HTML at build time.
- Add dynamic fetching of blog routes to ensure all posts have SEO meta tags pre-generated.
- Switch Vite config to use createRequire to fix ES module compatibility issues with prerender plugin.
- Update tsconfig.node.json and install @types/node to resolve type errors.
- Fix duplicate prop warning in L1MetricsChart.tsx.