### PR TITLE
fix: configure prerendering for SEO and update domain

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -24,12 +24,14 @@ export function SEO({
     author,
     tags = [],
 }: SEOProps) {
-    const siteUrl = 'https://l1beat-dev.netlify.app';
-    const fullUrl = url ? `${siteUrl}${url}` : siteUrl;
+    const siteUrl = 'https://l1beat.io';
+    const fullUrl = url ? (url.startsWith('http') ? url : `${siteUrl}${url}`) : siteUrl;
     const fullTitle = `${title} | L1Beat`;
 
     // Use a default image if none provided
-    const ogImage = image || `${siteUrl}/og-default.png`;
+    const ogImage = image 
+        ? (image.startsWith('http') ? image : `${siteUrl}${image}`)
+        : `${siteUrl}/og-default.png`;
 
     return (
         <Helmet>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,7 +73,7 @@ export default defineConfig(async ({ mode }) => {
           // Replace any localhost references with production URL if necessary
           renderedRoute.html = renderedRoute.html.replace(
             /http:\/\/localhost:\d+/g, 
-            'https://l1beat.com'
+            'https://l1beat.io'
           );
           return renderedRoute;
         },


### PR DESCRIPTION
- Enable vite-plugin-prerender in vite.config.ts to generate static HTML for blog posts.
- Fix ES module compatibility issues with prerender plugin using createRequire.
- Update site URL to https://l1beat.io in SEO.tsx and vite.config.ts.
- Resolve duplicate props in L1MetricsChart.tsx.
- Update package.json and tsconfig.node.json for build dependencies.