### PR TITLE
fix: extract blog post images from content for SEO previews

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -20,6 +20,7 @@ import {
     Sparkles
 } from 'lucide-react';
 import { BlogPost as BlogPostType, getBlogPost, formatBlogDate, calculateReadTime, getRelatedPosts, RelatedPost } from '../api/blogApi';
+import { getBlogPostImageUrl } from '../utils/imageExtractor';
 import { AuthorCard } from '../components/AuthorCard';
 import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
@@ -363,6 +364,7 @@ export function BlogPost() {
 
     const readTime = post.readTime || calculateReadTime(post.content || '');
     const formattedDate = formatBlogDate(post.publishedAt || '');
+    const seoImage = getBlogPostImageUrl(post);
 
     return (
         <div className="min-h-screen bg-gray-50 dark:bg-dark-900">
@@ -370,7 +372,7 @@ export function BlogPost() {
             <SEO
                 title={post.title}
                 description={post.excerpt || post.subtitle || ''}
-                image={post.imageUrl}
+                image={seoImage}
                 url={`/blog/${post.slug}`}
                 type="article"
                 publishedTime={post.publishedAt}

--- a/src/utils/imageExtractor.ts
+++ b/src/utils/imageExtractor.ts
@@ -96,7 +96,7 @@ function cleanImageUrl(url: string): string | null {
  */
 export function getFallbackImageUrl(): string {
     // Return a fallback image
-    return 'https://i.postimg.cc/zvYYZ8Ks/image.png';
+    return '/banner.png';
 }
 
 /**


### PR DESCRIPTION
- Update `BlogPost.tsx` to use `getBlogPostImageUrl` for generating SEO meta tags.
- This ensures link previews display an image (extracted from the content body) even if the API response lacks a dedicated `imageUrl` field.
- Update `imageExtractor.ts` to use the local `/banner.png` as the fallback image instead of an external placeholder.