### PR TITLE
fix: add prerenderReady flag for Netlify SEO

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -184,6 +184,10 @@ export function BlogPost() {
             navigate('/blog');
             return;
         }
+        
+        // Reset prerenderReady
+        window.prerenderReady = false;
+        
         fetchPost();
     }, [slug, navigate]);
 
@@ -204,6 +208,8 @@ export function BlogPost() {
             console.error('Error fetching post:', err);
         } finally {
             setLoading(false);
+            // Mark as ready for prerendering
+            window.prerenderReady = true;
         }
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+declare global {
+  interface Window {
+    prerenderReady?: boolean;
+  }
+}
+
 // Chain related types
 export interface Chain {
   chainId: string;


### PR DESCRIPTION
- Update  to include  in the Window interface.
- Update  to manage  state.
- This ensures Netlify's prerender service waits for the API data fetch to complete (and the SEO component to render) before snapshotting the page, fixing the issue where link previews showed the default loading state.