### PR TITLE
fix: force JPG format for Substack images in SEO tags

### DIFF
--- a/src/utils/imageExtractor.ts
+++ b/src/utils/imageExtractor.ts
@@ -76,6 +76,11 @@ function cleanImageUrl(url: string): string | null {
         return cleaned;
     }
 
+    // Optimize Substack images for Twitter/Social Media (convert WebP to JPG)
+    if (cleaned.includes('substackcdn.com') && cleaned.includes('f_webp')) {
+        cleaned = cleaned.replace('f_webp', 'f_jpg');
+    }
+
     // Basic URL validation - accept various formats
     if (
         cleaned.startsWith('http://') ||


### PR DESCRIPTION
- Update `src/utils/imageExtractor.ts` to replace `f_webp` with `f_jpg` in extracted Substack image URLs.
- This ensures compatibility with Twitter/X link previews, which often fail to display WebP images.