### PR TITLE
fix: Improve metrics data handling and replace gas metric with vaidators count

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest } from './types';
+import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal } from './types';
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
@@ -780,6 +780,36 @@ export async function getChainGasUsedLatest(chainId: string): Promise<GasUsedLat
     } catch (error) {
       console.error('Chain gas used latest fetch error:', error);
       return null;
+    }
+  });
+}
+
+export async function getNetworkValidatorTotal(): Promise<NetworkValidatorTotal> {
+  return fetchWithCache('network-validator-total', async () => {
+    try {
+      const response = await fetchWithRetry<{
+        success: boolean;
+        totalValidators: number;
+        chainsWithValidators: number;
+        timestamp: string;
+      }>(`${API_URL}/validators/network/total`);
+
+      if (!response.success) {
+        throw new Error('Invalid network validator total response format');
+      }
+
+      return {
+        totalValidators: response.totalValidators || 0,
+        chainsWithValidators: response.chainsWithValidators || 0,
+        timestamp: response.timestamp || new Date().toISOString()
+      };
+    } catch (error) {
+      console.error('Network validator total fetch error:', error);
+      return {
+        totalValidators: 0,
+        chainsWithValidators: 0,
+        timestamp: new Date().toISOString()
+      };
     }
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,13 @@ export interface FeesPaidLatest {
   chainCount?: number; // For network-wide stats
 }
 
+// Network Validator types
+export interface NetworkValidatorTotal {
+  totalValidators: number;
+  chainsWithValidators: number;
+  timestamp: string;
+}
+
 // Health related types
 export interface HealthStatus {
   status: string;


### PR DESCRIPTION
- Fix NetworkMetricsBar to show yesterday's complete data when today's data is incomplete - Show yesterday's metrics if < 6 hours since midnight or if today's value < 20% of yesterday - Applies to TPS, Max TPS, and Tx Count metrics - Prevents confusing 0 or low values early in the day
- Fix AvalancheNetworkMetrics to use proper API wrapper (getTPSHistory)
- Replace manual fetch call with API function that includes caching and retry logic
- Add proper error handling for empty data responses - Always show metric selector and timeframe buttons even when data is unavailable
- Replace Daily Gas Used with Total Validators in metrics bar - Add NetworkValidatorTotal type and getNetworkValidatorTotal() API function - Display full validator count (2,849) instead of abbreviated format - Show validator count across 62 chains

   Technical changes:
   - Add NetworkValidatorTotal interface to types.ts
   - Add getNetworkValidatorTotal() to api.ts with /api/validators/network/total endpoint
   - Update NetworkMetricsBar to fetch history data and implement smart fallback logic
   - Refactor AvalancheNetworkMetrics to show empty state without hiding controls