### PR TITLE
  fix: Replace old fallback logo with new animated L1Beat icon

### DIFF
--- a/src/components/ChainCard.tsx
+++ b/src/components/ChainCard.tsx
@@ -57,13 +57,13 @@ export function ChainCard({ chain }: ChainCardProps) {
                 whileHover={{ scale: 1.1, rotate: 5 }}
                 transition={{ duration: 0.2, ease: "easeOut" }}
                 onError={(e) => {
-                  e.currentTarget.src = "https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg";
+                  e.currentTarget.src = "/icon-dark-animated.svg";
                   e.currentTarget.onerror = null;
                 }}
               />
             ) : (
               <motion.img
-                src="https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg"
+                src="/icon-dark-animated.svg"
                 alt={`${chain.chainName} logo`}
                 className="w-10 h-10 rounded-lg shadow-sm"
                 whileHover={{ scale: 1.1, rotate: 5 }}
@@ -176,7 +176,7 @@ export function ChainCard({ chain }: ChainCardProps) {
                   alt={`${chain.networkToken.name} logo`}
                   className="w-5 h-5 rounded-full"
                   onError={(e) => {
-                    e.currentTarget.src = "https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg";
+                    e.currentTarget.src = "/icon-dark-animated.svg";
                     e.currentTarget.onerror = null;
                   }}
                 />

--- a/src/components/ChainListView.tsx
+++ b/src/components/ChainListView.tsx
@@ -64,13 +64,13 @@ export function ChainListView({ chains }: ChainListViewProps) {
                   whileHover={{ scale: 1.1 }}
                   transition={{ duration: 0.2, ease: "easeOut" }}
                   onError={(e) => {
-                    e.currentTarget.src = "https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg";
+                    e.currentTarget.src = "/icon-dark-animated.svg";
                     e.currentTarget.onerror = null;
                   }}
                 />
               ) : (
                 <motion.img
-                  src="https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg"
+                  src="/icon-dark-animated.svg"
                   alt={`${chain.chainName} logo`}
                   className="w-10 h-10 rounded-lg shadow-sm flex-shrink-0 bg-white dark:bg-gray-900"
                   whileHover={{ scale: 1.1 }}

--- a/src/components/NetworkTopologyGraph.tsx
+++ b/src/components/NetworkTopologyGraph.tsx
@@ -559,13 +559,13 @@ export function NetworkTopologyGraph() {
                       alt={chain.chainName}
                       className="w-2/3 h-2/3 object-contain rounded-full"
                       onError={(e) => {
-                        e.currentTarget.src = "https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg";
+                        e.currentTarget.src = "/icon-dark-animated.svg";
                         e.currentTarget.onerror = null;
                       }}
                     />
                   ) : (
                     <img
-                      src="https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg"
+                      src="/icon-dark-animated.svg"
                       alt={chain.chainName}
                       className="w-2/3 h-2/3 object-contain rounded-full"
                     />

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -288,7 +288,7 @@ export function ChainDetails() {
                           alt={`${chain.chainName} logo`}
                           className="w-20 h-20 rounded-2xl shadow-md bg-transparent p-2"
                           onError={(e) => {
-                            e.currentTarget.src = "https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg";
+                            e.currentTarget.src = "/icon-dark-animated.svg";
                             e.currentTarget.onerror = null;
                           }}
                         />
@@ -299,7 +299,7 @@ export function ChainDetails() {
                     ) : (
                       <div className="relative flex-shrink-0">
                         <img
-                          src="https://i.postimg.cc/gcq3RxBm/SAVE-20251114-181539.jpg"
+                          src="/icon-dark-animated.svg"
                           alt={`${chain.chainName} logo`}
                           className="w-20 h-20 rounded-2xl shadow-md bg-transparent p-2"
                         />


### PR DESCRIPTION
  Replace deprecated postimg.cc fallback logo URL with local animated icon
  (/icon-dark-animated.svg) across all chain display components.

  Changes:
  - Update ChainCard.tsx: Replace fallback for chain and token logos
  - Update ChainDetails.tsx: Replace fallback in chain detail header
  - Update NetworkTopologyGraph.tsx: Replace fallback in topology graph nodes
  - Update ChainListView.tsx: Replace fallback in list view

  The animated heartbeat icon now displays when:
  - Chain has no chainLogoUri in API response
  - Chain logo fails to load (onError fallback)
  - Token logo fails to load

  This provides consistent branding with the new L1Beat visual identity