### PR TITLE
  fix: use validatorCount field instead of validators array length

### DIFF
--- a/src/components/ChainCard.tsx
+++ b/src/components/ChainCard.tsx
@@ -117,7 +117,7 @@ export function ChainCard({ chain }: ChainCardProps) {
             </div>
             <AnimatePresence mode="popLayout">
               <motion.span
-                key={chain.validators?.length || 0}
+                key={chain.validatorCount}
                 initial={{ opacity: 0, y: 5, scale: 0.95 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: -5, scale: 0.95 }}
@@ -127,7 +127,7 @@ export function ChainCard({ chain }: ChainCardProps) {
                 }}
                 className="text-lg font-bold text-[#ef4444] dark:text-[#ef4444] inline-block"
               >
-                {chain.validators?.length || 0}
+                {chain.validatorCount || 0}
               </motion.span>
             </AnimatePresence>
           </motion.div>

--- a/src/components/ChainListView.tsx
+++ b/src/components/ChainListView.tsx
@@ -93,7 +93,7 @@ export function ChainListView({ chains }: ChainListViewProps) {
                   <div className="flex items-center gap-1 min-w-[30px]">
                     <Server className="w-3 h-3 text-gray-400 dark:text-gray-500 flex-shrink-0" />
                     <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-                      {chain.validators?.length || 0}
+                      {chain.validatorCount || 0}
                     </span>
                   </div>
                   <div className="w-px h-3 bg-gray-200 dark:bg-gray-700 flex-shrink-0"></div>

--- a/src/components/NetworkTopologyGraph.tsx
+++ b/src/components/NetworkTopologyGraph.tsx
@@ -51,7 +51,7 @@ export function NetworkTopologyGraph() {
         if (chainsData && chainsData.length > 0) {
           // Filter chains to include those with validators OR Avalanche chains
           const validChains = chainsData.filter(chain => 
-            (chain.validators && chain.validators.length > 0) ||
+            (chain.validatorCount && chain.validatorCount > 0) ||
             chain.chainName.toLowerCase().includes('avalanche') ||
             chain.chainName.toLowerCase().includes('c-chain')
           );
@@ -595,7 +595,7 @@ export function NetworkTopologyGraph() {
                   </span>
                 )}
                 <span className="text-xs text-gray-400">
-                  {hoveredChain.validators?.length || 0} validators
+                  {hoveredChain.validatorCount || hoveredChain.validators?.length || 0} validators
                 </span>
               </div>
               {/* Tooltip arrow */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -61,7 +61,7 @@ export function Dashboard() {
       if (!showChainsWithoutValidators) {
         // Default behavior: only show chains with validators or Avalanche primary chains
         filteredChains = filteredChains.filter(chain =>
-          (chain.validators && chain.validators.length >= 1) ||
+          (chain.validatorCount && chain.validatorCount >= 1) ||
           chain.chainName.toLowerCase().includes('avalanche') ||
           chain.chainName.toLowerCase().includes('c-chain')
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ declare global {
 // Chain related types
 export interface Chain {
   chainId: string;
+  originalChainId?: string;
   chainName: string;
   chainLogoUri?: string;
   description?: string;
@@ -16,6 +17,7 @@ export interface Chain {
     value: number;
     timestamp: number;
   } | null;
+  validatorCount?: number;
   cumulativeTxCount?: {
     value: number;
     timestamp: number;


### PR DESCRIPTION
  Backend API removed the validators array from /api/chains endpoint,
  keeping only the validatorCount field. This caused validator counts
  to display as 0 in chain cards.

  Changes:
  - Add getChainValidators() function to fetch validators from dedicated endpoint
  - Update all components to use chain.validatorCount instead of chain.validators.length
    - ChainCard, ChainListView, NetworkTopologyGraph, Dashboard
  - Enhance getChains() to handle multiple validator count field names for robustness
  - Add cache clearing utility for development
  - Update ChainDetails to fetch validators from dedicated endpoint
  - Add originalChainId and validatorCount to Chain type definition
  - Remove unused activeValidators variable

  Fixes validator count display in both Grid and List views.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace validators array usage with validatorCount across UI, add per-chain validators fetch with caching, and update types and IDs for robustness.
> 
> - **API**:
>   - Enhance `getChains` to map `validatorCount` from multiple possible fields and normalize `tps`, `cumulativeTxCount`, `chainId` slug, and `originalChainId`.
>   - Add `getChainValidators(chainId)` to fetch validators from `GET /api/chains/:id/validators` with caching.
>   - Introduce `clearChainsCache()` and invoke on module load to refresh chains cache.
> - **UI**:
>   - Use `chain.validatorCount` instead of `validators.length` in `components/ChainCard.tsx`, `ChainListView.tsx`, `NetworkTopologyGraph.tsx`, and validator filtering in `pages/Dashboard.tsx`.
>   - In `pages/ChainDetails.tsx`, fetch validators via `getChainValidators` and prefer `originalChainId` for metrics requests and display.
> - **Types**:
>   - Extend `Chain` with `originalChainId` and `validatorCount`; export `Validator` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2648e67578cab7e1d0dd0260efaca4795fe1415b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->