### PR TITLE
feat(chain-details): show remaining balance when uptime missing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface Validator {
   active: boolean;
   uptime: number;
   weight: number;
+  stakeUnit?: 'tokens' | 'weight';
+  remainingBalance?: number;
   explorerUrl?: string;
 }
 


### PR DESCRIPTION
Detect stake source (amountStaked vs weight) on validators, label units accordingly, and add weight tooltips. Add remainingBalance support and display it in AVAX with runway-based coloring when uptime isn’t available.