### PR TITLE
Fix validator stake precision, token decimals, and ChainDetails UI polish

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -350,7 +350,7 @@ export function BlogPost() {
         return (
             <div className="min-h-screen bg-background text-foreground">
                 <StatusBar health={health} />
-                <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+                <div className="max-w-4xl xl:max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
                     <div className="text-center">
                         <div className="relative inline-block mb-8">
                             <div className="w-24 h-24 bg-gradient-to-br from-red-100 to-red-200 dark:from-red-900/30 dark:to-red-800/30 rounded-2xl flex items-center justify-center">
@@ -431,7 +431,7 @@ export function BlogPost() {
             <StatusBar health={health} />
 
             {/* Article */}
-            <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <article className="max-w-4xl xl:max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
                 {/* Simple Back Button */}
                 <div className="mb-8">
                     <Link
@@ -598,7 +598,7 @@ export function BlogPost() {
 
             {/* Newsletter and Related Articles Section */}
             <div className="bg-card border-t border-border">
-                <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+                <div className="max-w-4xl xl:max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
                     {/* Newsletter Subscription */}
                     <div className="mb-16">
                         <NewsletterSubscription />

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { StatusBar } from '../components/StatusBar';
 import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
+import { Footer } from '../components/Footer';
 import { getHealth } from '../api';
-import { useEffect, useState } from 'react';
 import { HealthStatus } from '../types';
-import { BarChart3 } from 'lucide-react';
 
 export function Metrics() {
   const [health, setHealth] = useState<HealthStatus | null>(null);
@@ -34,6 +33,8 @@ export function Metrics() {
         {/* Chain-Specific Metrics */}
         <ChainSpecificMetrics />
       </main>
+
+      <Footer />
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface Chain {
   chainName: string;
   chainLogoUri?: string;
   description?: string;
+  isL1?: boolean;
+  sybilResistanceType?: string;
   subnetId?: string;
   platformChainId?: string;
   tps: {
@@ -61,7 +63,11 @@ export interface Validator {
   address: string;
   active: boolean;
   uptime: number;
-  weight: number;
+  /**
+   * Validator stake/weight amount in nAVAX (1 AVAX = 1e9 nAVAX).
+   * Kept as string to preserve precision for very large values.
+   */
+  weight: string;
   stakeUnit?: 'tokens' | 'weight';
   remainingBalance?: number;
   explorerUrl?: string;

--- a/src/utils/avax.ts
+++ b/src/utils/avax.ts
@@ -1,0 +1,89 @@
+export type NavaxLike = string | number | bigint | null | undefined;
+
+const NAVAX_PER_AVAX = 1_000_000_000n;
+const NAVAX_PER_CENTI_AVAX = 10_000_000n; // 0.01 AVAX
+const ROUNDING_HALF_UP = 5_000_000n; // half of 1e7
+
+export function parseNavax(value: NavaxLike): bigint | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'bigint') return value;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    // Note: numbers may be imprecise for large nAVAX; prefer string inputs.
+    return BigInt(Math.trunc(value));
+  }
+
+  const raw = String(value).trim();
+  if (raw.length === 0) return null;
+
+  // Accept hex BigInt strings too.
+  if (/^-?0x[0-9a-fA-F]+$/.test(raw)) {
+    try {
+      return BigInt(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  // We expect integer nAVAX strings; reject decimals/scientific to avoid silent corruption.
+  if (!/^-?\d+$/.test(raw)) return null;
+  try {
+    return BigInt(raw);
+  } catch {
+    return null;
+  }
+}
+
+function groupThousands(intStr: string): string {
+  // intStr should be digits only (no sign)
+  return intStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+/**
+ * Convert nAVAX -> AVAX (divide by 1e9) and format with thousand separators.
+ * - Returns whole numbers or up to 2 decimals (rounded half-up)
+ * - Accepts string/BigInt to preserve precision for large values
+ */
+export function formatNavaxToAvax(value: NavaxLike): string {
+  const navax = parseNavax(value);
+  if (navax === null) return 'N/A';
+
+  const isNegative = navax < 0n;
+  const abs = isNegative ? -navax : navax;
+
+  // Round to 2 decimal places (centi-AVAX) using integer math.
+  const roundedCenti = (abs + ROUNDING_HALF_UP) / NAVAX_PER_CENTI_AVAX; // in 0.01 AVAX units
+  const intPart = roundedCenti / 100n;
+  const decPart = roundedCenti % 100n;
+
+  const intStr = groupThousands(intPart.toString());
+
+  if (decPart === 0n) {
+    return isNegative ? `-${intStr}` : intStr;
+  }
+
+  // Trim trailing zeros (max 2 decimals)
+  let decStr = decPart.toString().padStart(2, '0');
+  if (decStr.endsWith('0')) decStr = decStr.slice(0, 1);
+
+  return isNegative ? `-${intStr}.${decStr}` : `${intStr}.${decStr}`;
+}
+
+/**
+ * Best-effort conversion for computations (charts/percentages).
+ * Returns a JS number in AVAX, potentially losing precision for extremely large values.
+ */
+export function navaxToAvaxNumber(value: NavaxLike): number {
+  const navax = parseNavax(value);
+  if (navax === null) return NaN;
+  // Use quotient + remainder to keep some fractional precision.
+  const isNegative = navax < 0n;
+  const abs = isNegative ? -navax : navax;
+  const q = abs / NAVAX_PER_AVAX;
+  const r = abs % NAVAX_PER_AVAX;
+  const n = Number(q) + Number(r) / 1e9;
+  return isNegative ? -n : n;
+}
+
+

--- a/src/utils/formatUnits.ts
+++ b/src/utils/formatUnits.ts
@@ -1,0 +1,138 @@
+export type BaseUnitLike = string | number | bigint | null | undefined;
+
+const POW10_CACHE = new Map<number, bigint>([
+  [0, 1n],
+  [1, 10n],
+  [2, 100n],
+  [3, 1000n],
+  [6, 1_000_000n],
+  [9, 1_000_000_000n],
+  [18, 1_000_000_000_000_000_000n],
+]);
+
+function pow10(decimals: number): bigint {
+  if (!Number.isFinite(decimals) || decimals < 0) return 1n;
+  const d = Math.floor(decimals);
+  const cached = POW10_CACHE.get(d);
+  if (cached) return cached;
+  let v = 1n;
+  for (let i = 0; i < d; i++) v *= 10n;
+  POW10_CACHE.set(d, v);
+  return v;
+}
+
+export function parseBaseUnits(value: BaseUnitLike): bigint | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'bigint') return value;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    // Note: numbers can be imprecise for large values; prefer string.
+    return BigInt(Math.trunc(value));
+  }
+
+  const raw = String(value).trim();
+  if (raw.length === 0) return null;
+
+  if (/^-?0x[0-9a-fA-F]+$/.test(raw)) {
+    try {
+      return BigInt(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  if (!/^-?\d+$/.test(raw)) return null;
+  try {
+    return BigInt(raw);
+  } catch {
+    return null;
+  }
+}
+
+function groupThousands(intStr: string): string {
+  return intStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+export interface FormatUnitsOptions {
+  /** Max decimals to show (rounded half-up). Default: 2 */
+  maxFractionDigits?: number;
+}
+
+/**
+ * Format a base-unit integer into human units using `decimals`.
+ * - BigInt-safe (no precision loss)
+ * - Adds thousand separators
+ * - Shows whole numbers or up to `maxFractionDigits` decimals
+ */
+export function formatUnits(
+  baseUnits: BaseUnitLike,
+  decimals: number,
+  opts: FormatUnitsOptions = {}
+): string {
+  const v = parseBaseUnits(baseUnits);
+  if (v === null) return 'N/A';
+
+  const isNegative = v < 0n;
+  const abs = isNegative ? -v : v;
+
+  const d = Number.isFinite(decimals) ? Math.max(0, Math.floor(decimals)) : 0;
+  const maxFrac = opts.maxFractionDigits ?? 2;
+  const fracDigits = Math.max(0, Math.min(Math.floor(maxFrac), d));
+
+  const scale = pow10(d);
+
+  // Integer part
+  let intPart = abs / scale;
+  let remainder = abs % scale;
+
+  if (fracDigits === 0) {
+    const out = groupThousands(intPart.toString());
+    return isNegative ? `-${out}` : out;
+  }
+
+  // We want to compute fractional part with rounding at `fracDigits`.
+  // Compute: round(remainder / 10^(d-fracDigits)) as an integer in [0, 10^fracDigits)
+  const cutScale = pow10(d - fracDigits); // base units per displayed fractional unit
+  let frac = remainder / cutScale;
+  const cutRemainder = remainder % cutScale;
+  // Half-up rounding
+  if (cutRemainder * 2n >= cutScale) {
+    frac += 1n;
+  }
+
+  const fracBase = pow10(fracDigits);
+  if (frac >= fracBase) {
+    // carry
+    intPart += 1n;
+    frac = 0n;
+  }
+
+  const intStr = groupThousands(intPart.toString());
+
+  let fracStr = frac.toString().padStart(fracDigits, '0');
+  // Trim trailing zeros for readability (keep at least 0 digits -> handled above)
+  while (fracStr.endsWith('0')) fracStr = fracStr.slice(0, -1);
+
+  const out = fracStr.length ? `${intStr}.${fracStr}` : intStr;
+  return isNegative ? `-${out}` : out;
+}
+
+/**
+ * Best-effort conversion for computations (charts/percentages).
+ * May lose precision for extremely large values.
+ */
+export function unitsToNumber(baseUnits: BaseUnitLike, decimals: number): number {
+  const v = parseBaseUnits(baseUnits);
+  if (v === null) return NaN;
+  const isNegative = v < 0n;
+  const abs = isNegative ? -v : v;
+  const d = Number.isFinite(decimals) ? Math.max(0, Math.floor(decimals)) : 0;
+  const scale = pow10(d);
+  const q = abs / scale;
+  const r = abs % scale;
+  const n = Number(q) + Number(r) / Number(scale);
+  return isNegative ? -n : n;
+}
+
+


### PR DESCRIPTION
Fixed validator stake/weight precision by keeping base-unit amounts as strings and formatting with BigInt-safe helpers.
Aligned stake display with chain nativeToken.decimals (default 18) and added an AVAX nAVAX (9-decimal) override for validator stake.
Updated Chain Details UX (Type/Sybil Resistance tiles, “EVM Chain ID” label) and restyled Stake Distribution to match brand surfaces; added Metrics footer and widened BlogPost layout on xl screens.
