### PR TITLE
fix: Native token image fallback handler

### DIFF
--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -365,11 +365,8 @@ export const ChainTableView = memo(function ChainTableView({
                         alt={chain.networkToken?.symbol || chain.chainName}
                         className="w-4 h-4 rounded-full"
                         onError={(e) => {
-                          const target = e.currentTarget;
-                          if (target.src !== "/icon-dark-animated.svg") {
-                            target.src =
-                              chain.chainLogoUri || "/icon-dark-animated.svg";
-                          }
+                          e.currentTarget.src = "/icon-dark-animated.svg";
+                          e.currentTarget.onerror = null;
                         }}
                       />
                       <span className="text-sm font-medium text-gray-900 dark:text-gray-100">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change affecting image fallback behavior; low blast radius and no data/auth impact.
> 
> **Overview**
> Fixes the native token logo fallback in `ChainTableView` by simplifying the `img` `onError` handler to always swap to `/icon-dark-animated.svg` and then disable further error handling to avoid repeated failures/loops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66d8ac85d42313034dace30e15a2a0eb50f5ac04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->