### PR TITLE
Feature/l1beat api integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=your_api_base_url_here
 # http://localhost:5001
+VITE_L1BEAT_EXTERNAL_API=https://api.l1beat.io

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ ACPs/index.json
 CLAUDE.md
 SEO_IMPLEMENTATION.md
 .docs
+.serena

--- a/scripts/ssg.js
+++ b/scripts/ssg.js
@@ -86,7 +86,7 @@ async function generate() {
         if (match) return match[1].trim();
       } catch (e) {}
       
-      return 'https://api.l1beat.io'; // Default fallback
+      return process.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io'; // Default fallback
     };
     
     const apiBaseUrl = await getApiUrl();

--- a/src/api.ts
+++ b/src/api.ts
@@ -1439,39 +1439,105 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
 
 const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
+// Fetch from external APIs without headers that trigger CORS preflight.
+// Only sends Accept: application/json (a CORS-safe header).
+async function fetchExternalWithRetry<T>(
+  url: string,
+  retries: number = 3,
+  backoffFactor: number = 2,
+  timeout: number = 30000
+): Promise<T> {
+  let lastError: Error = new Error('Unknown error occurred');
+  let attempt = 0;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    while (attempt < retries) {
+      try {
+        const response = await fetch(url, {
+          signal: controller.signal,
+          mode: 'cors',
+          credentials: 'omit',
+          headers: { 'Accept': 'application/json' },
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        return await response.json() as T;
+      } catch (error) {
+        lastError = error as Error;
+
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw new Error('Request timeout');
+        }
+
+        attempt++;
+        if (attempt === retries) break;
+
+        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
+    throw lastError;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// Paginate through all pages of an L1Beat external API endpoint.
+async function fetchAllL1BeatPages<T>(
+  endpoint: string,
+  extraParams: Record<string, string> = {}
+): Promise<T[]> {
+  const all: T[] = [];
+  let offset = 0;
+  const limit = 100;
+  let hasMore = true;
+
+  while (hasMore) {
+    const params = new URLSearchParams({ ...extraParams, limit: String(limit), offset: String(offset) });
+    const response = await fetchExternalWithRetry<{ data: T[]; meta: { has_more: boolean } }>(
+      `${L1BEAT_EXTERNAL_API}${endpoint}?${params.toString()}`
+    );
+    const chunk = response.data ?? [];
+    all.push(...chunk);
+    hasMore = response.meta?.has_more ?? false;
+    offset += limit;
+  }
+
+  return all;
+}
+
 export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
   const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
   return fetchWithCache(cacheKey, async () => {
     try {
-      const params = new URLSearchParams();
-      if (subnetId) params.set('subnet_id', subnetId);
-      if (active !== undefined) params.set('active', String(active));
-      params.set('limit', '1000');
-      const response = await fetchWithRetry<{ data: L1BeatValidatorRecord[] }>(
-        `${L1BEAT_EXTERNAL_API}/api/v1/data/validators?${params.toString()}`
-      );
-      return response.data ?? [];
+      const extraParams: Record<string, string> = {};
+      if (subnetId) extraParams['subnet_id'] = subnetId;
+      if (active !== undefined) extraParams['active'] = String(active);
+      return await fetchAllL1BeatPages<L1BeatValidatorRecord>('/api/v1/data/validators', extraParams);
     } catch (error) {
       console.error('L1Beat validators fetch error:', error);
       return [];
     }
-  }, 5 * 60 * 1000); // 5 min cache
+  }, 5 * 60 * 1000);
 }
 
 export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
   const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
   return fetchWithCache(cacheKey, async () => {
     try {
-      const params = new URLSearchParams();
-      if (subnetId) params.set('subnet_id', subnetId);
-      params.set('limit', '1000');
-      const response = await fetchWithRetry<{ data: L1BeatFeeMetrics[] }>(
-        `${L1BEAT_EXTERNAL_API}/api/v1/metrics/fees?${params.toString()}`
-      );
-      return response.data ?? [];
+      const extraParams: Record<string, string> = {};
+      if (subnetId) extraParams['subnet_id'] = subnetId;
+      return await fetchAllL1BeatPages<L1BeatFeeMetrics>('/api/v1/metrics/fees', extraParams);
     } catch (error) {
       console.error('L1Beat fee metrics fetch error:', error);
       return [];
     }
-  }, 5 * 60 * 1000); // 5 min cache
+  }, 5 * 60 * 1000);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1437,7 +1437,7 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
   }, 15 * 60 * 1000); // Cache for 15 minutes
 }
 
-const L1BEAT_EXTERNAL_API = 'https://api.l1beat.io';
+const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
 export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
   const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatValidatorRecord, L1BeatFeeMetrics } from './types';
+import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatFeeMetrics } from './types';
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
@@ -1439,8 +1439,27 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
 
 const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
-// Fetch from external APIs without headers that trigger CORS preflight.
-// Only sends Accept: application/json (a CORS-safe header).
+// Cache wrapper for external API calls — skips the internal rate limiter since
+// these calls go to a different origin and should not consume the backend quota.
+async function fetchExternalWithCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  duration: number = CACHE_DURATION
+): Promise<T> {
+  const cached = cache.get(key);
+  const now = Date.now();
+  if (cached && now - cached.timestamp < duration) {
+    return cached.data;
+  }
+  const data = await fetcher();
+  const sanitizedData = sanitizeResponse(data);
+  cache.set(key, { data: sanitizedData, timestamp: now });
+  return sanitizedData;
+}
+
+// Fetch from external APIs with only CORS-safe headers (no Cache-Control /
+// Content-Type / Origin that trigger a preflight). Creates a fresh
+// AbortController per attempt so retries are not dead after a timeout.
 async function fetchExternalWithRetry<T>(
   url: string,
   retries: number = 3,
@@ -1448,48 +1467,44 @@ async function fetchExternalWithRetry<T>(
   timeout: number = 30000
 ): Promise<T> {
   let lastError: Error = new Error('Unknown error occurred');
-  let attempt = 0;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-  try {
-    while (attempt < retries) {
-      try {
-        const response = await fetch(url, {
-          signal: controller.signal,
-          mode: 'cors',
-          credentials: 'omit',
-          headers: { 'Accept': 'application/json' },
-        });
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        mode: 'cors',
+        credentials: 'omit',
+        headers: { 'Accept': 'application/json' },
+      });
 
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
 
-        return await response.json() as T;
-      } catch (error) {
-        lastError = error as Error;
+      return await response.json() as T;
+    } catch (error) {
+      lastError = error instanceof DOMException && error.name === 'AbortError'
+        ? new Error('Request timeout')
+        : error as Error;
 
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          throw new Error('Request timeout');
-        }
-
-        attempt++;
-        if (attempt === retries) break;
-
-        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
+      if (attempt < retries - 1) {
+        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt + 1), 10000);
         await new Promise(resolve => setTimeout(resolve, delay));
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
-
-    throw lastError;
-  } finally {
-    clearTimeout(timeoutId);
   }
+
+  throw lastError;
 }
 
 // Paginate through all pages of an L1Beat external API endpoint.
+// Stops when has_more is false or a page returns no data (guards against a
+// stuck has_more=true from a misbehaving API).
 async function fetchAllL1BeatPages<T>(
   endpoint: string,
   extraParams: Record<string, string> = {}
@@ -1497,40 +1512,24 @@ async function fetchAllL1BeatPages<T>(
   const all: T[] = [];
   let offset = 0;
   const limit = 100;
-  let hasMore = true;
 
-  while (hasMore) {
+  while (true) {
     const params = new URLSearchParams({ ...extraParams, limit: String(limit), offset: String(offset) });
     const response = await fetchExternalWithRetry<{ data: T[]; meta: { has_more: boolean } }>(
       `${L1BEAT_EXTERNAL_API}${endpoint}?${params.toString()}`
     );
     const chunk = response.data ?? [];
     all.push(...chunk);
-    hasMore = response.meta?.has_more ?? false;
+    if (chunk.length === 0 || !response.meta?.has_more) break;
     offset += limit;
   }
 
   return all;
 }
 
-export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
-  const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
-  return fetchWithCache(cacheKey, async () => {
-    try {
-      const extraParams: Record<string, string> = {};
-      if (subnetId) extraParams['subnet_id'] = subnetId;
-      if (active !== undefined) extraParams['active'] = String(active);
-      return await fetchAllL1BeatPages<L1BeatValidatorRecord>('/api/v1/data/validators', extraParams);
-    } catch (error) {
-      console.error('L1Beat validators fetch error:', error);
-      return [];
-    }
-  }, 5 * 60 * 1000);
-}
-
 export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
   const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
-  return fetchWithCache(cacheKey, async () => {
+  return fetchExternalWithCache(cacheKey, async () => {
     try {
       const extraParams: Record<string, string> = {};
       if (subnetId) extraParams['subnet_id'] = subnetId;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator } from './types';
+import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatValidatorRecord, L1BeatFeeMetrics } from './types';
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
@@ -1424,15 +1424,54 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
       const response = await fetchWithRetry<{ data: TeleporterDailyData[] }>(
         `${API_URL}/teleporter/messages/historical-daily?days=${days}`
       );
-      
+
       if (!response.data || !Array.isArray(response.data)) {
         throw new Error('Invalid Teleporter daily history data format');
       }
-      
+
       return response.data;
     } catch (error) {
       console.error('Teleporter daily history fetch error:', error);
       return [];
     }
   }, 15 * 60 * 1000); // Cache for 15 minutes
+}
+
+const L1BEAT_EXTERNAL_API = 'https://api.l1beat.io';
+
+export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
+  const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
+  return fetchWithCache(cacheKey, async () => {
+    try {
+      const params = new URLSearchParams();
+      if (subnetId) params.set('subnet_id', subnetId);
+      if (active !== undefined) params.set('active', String(active));
+      params.set('limit', '1000');
+      const response = await fetchWithRetry<{ data: L1BeatValidatorRecord[] }>(
+        `${L1BEAT_EXTERNAL_API}/api/v1/data/validators?${params.toString()}`
+      );
+      return response.data ?? [];
+    } catch (error) {
+      console.error('L1Beat validators fetch error:', error);
+      return [];
+    }
+  }, 5 * 60 * 1000); // 5 min cache
+}
+
+export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
+  const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
+  return fetchWithCache(cacheKey, async () => {
+    try {
+      const params = new URLSearchParams();
+      if (subnetId) params.set('subnet_id', subnetId);
+      params.set('limit', '1000');
+      const response = await fetchWithRetry<{ data: L1BeatFeeMetrics[] }>(
+        `${L1BEAT_EXTERNAL_API}/api/v1/metrics/fees?${params.toString()}`
+      );
+      return response.data ?? [];
+    } catch (error) {
+      console.error('L1Beat fee metrics fetch error:', error);
+      return [];
+    }
+  }, 5 * 60 * 1000); // 5 min cache
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,7 +69,7 @@ const DEFAULT_HEADERS = {
 };
 
 // Define constants for rate limiting
-const REQUEST_LIMIT = 50; // Max requests per minute
+const REQUEST_LIMIT = 200; // Max requests per minute
 const REQUEST_PERIOD = 60 * 1000; // 1 minute in milliseconds
 
 // Track API calls for rate limiting

--- a/src/components/ChainListView.tsx
+++ b/src/components/ChainListView.tsx
@@ -6,12 +6,14 @@ import { motion } from 'framer-motion';
 
 interface ChainListViewProps {
   chains: Chain[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 interface ChainListItemProps {
   chain: Chain;
   index: number;
   onNavigate: (chainId: string) => void;
+  validatorCount: number;
 }
 
 // Helper functions moved outside component
@@ -31,7 +33,7 @@ const getTPSColor = (tpsStr: string) => {
 };
 
 // Memoized list item to prevent re-renders during parent animations
-const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: ChainListItemProps) {
+const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate, validatorCount }: ChainListItemProps) {
   const tpsValue = formatTPS(chain.tps);
   const tpsColor = getTPSColor(tpsValue);
   
@@ -90,7 +92,7 @@ const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: 
             <div className="flex items-center gap-1 min-w-[30px]">
               <Server className="w-3 h-3 text-muted-foreground flex-shrink-0" />
               <span className="text-xs font-medium text-muted-foreground">
-                {chain.validatorCount || 0}
+                {validatorCount}
               </span>
             </div>
             <div className="w-px h-3 bg-border flex-shrink-0"></div>
@@ -110,13 +112,13 @@ const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: 
   return (
     prevProps.chain.chainId === nextProps.chain.chainId &&
     prevProps.chain.tps?.value === nextProps.chain.tps?.value &&
-    prevProps.chain.validatorCount === nextProps.chain.validatorCount &&
+    prevProps.validatorCount === nextProps.validatorCount &&
     prevProps.index === nextProps.index
   );
 });
 
 // Memoized container component
-export const ChainListView = memo(function ChainListView({ chains }: ChainListViewProps) {
+export const ChainListView = memo(function ChainListView({ chains, validatorCountBySubnet = {} }: ChainListViewProps) {
   const navigate = useNavigate();
 
   const handleNavigate = useCallback((chainId: string) => {
@@ -127,14 +129,18 @@ export const ChainListView = memo(function ChainListView({ chains }: ChainListVi
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
-      {chains.map((chain, index) => (
-        <ChainListItem
-          key={chain.chainId}
-          chain={chain}
-          index={index}
-          onNavigate={handleNavigate}
-        />
-      ))}
+      {chains.map((chain, index) => {
+        const validatorCount = (chain.subnetId ? validatorCountBySubnet[chain.subnetId] : undefined) ?? chain.validatorCount ?? 0;
+        return (
+          <ChainListItem
+            key={chain.chainId}
+            chain={chain}
+            index={index}
+            onNavigate={handleNavigate}
+            validatorCount={validatorCount}
+          />
+        );
+      })}
     </div>
   );
 });

--- a/src/components/ChainSpecificMetrics.tsx
+++ b/src/components/ChainSpecificMetrics.tsx
@@ -271,7 +271,17 @@ export function ChainSpecificMetrics() {
       }
     }
     fetchChains();
-  }, [chainParam]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync selected chain from URL param when chains are already loaded
+  useEffect(() => {
+    if (!chainParam || chains.length === 0) return;
+    const chainFromUrl = chains.find(c => c.chainId === chainParam);
+    if (chainFromUrl && chainFromUrl.chainId !== selectedChain?.chainId) {
+      setSelectedChain(chainFromUrl);
+    }
+  }, [chainParam, chains, selectedChain?.chainId]);
 
   // Background: compute latest daily active addresses per chain for ranking the quick-select row.
   useEffect(() => {

--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -365,11 +365,8 @@ export const ChainTableView = memo(function ChainTableView({
                         alt={chain.networkToken?.symbol || chain.chainName}
                         className="w-4 h-4 rounded-full"
                         onError={(e) => {
-                          const target = e.currentTarget;
-                          if (target.src !== "/icon-dark-animated.svg") {
-                            target.src =
-                              chain.chainLogoUri || "/icon-dark-animated.svg";
-                          }
+                          e.currentTarget.src = "/icon-dark-animated.svg";
+                          e.currentTarget.onerror = null;
                         }}
                       />
                       <span className="text-sm font-medium text-gray-900 dark:text-gray-100">

--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -16,6 +16,8 @@ import {
 interface ChainTableViewProps {
   chains: Chain[];
   icmMessageCounts?: Record<string, number>;
+  validatorCountBySubnet?: Record<string, number>;
+  feesBySubnet?: Record<string, number>;
 }
 
 type SortField =
@@ -66,6 +68,15 @@ const formatTimestamp = (timestamp: number | undefined) => {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+};
+
+const formatFeesAvax = (nAvax: number | undefined): string => {
+  if (nAvax === undefined || nAvax === null) return "N/A";
+  const avax = nAvax / 1_000_000_000;
+  if (avax === 0) return "0 AVAX";
+  if (avax >= 1_000_000) return `${(avax / 1_000_000).toFixed(2)}M AVAX`;
+  if (avax >= 1_000) return `${(avax / 1_000).toFixed(2)}K AVAX`;
+  return `${avax.toFixed(2)} AVAX`;
 };
 
 // Placeholder badge components for missing data
@@ -127,6 +138,8 @@ const SortHeader = ({
 export const ChainTableView = memo(function ChainTableView({
   chains,
   icmMessageCounts = {},
+  validatorCountBySubnet = {},
+  feesBySubnet = {},
 }: ChainTableViewProps) {
   const navigate = useNavigate();
   const [sortConfig, setSortConfig] = useState<SortConfig>({
@@ -176,8 +189,8 @@ export const ChainTableView = memo(function ChainTableView({
         return order * (tpsA - tpsB);
 
       case "validators":
-        const validatorsA = a.validatorCount ?? 0;
-        const validatorsB = b.validatorCount ?? 0;
+        const validatorsA = (a.subnetId ? validatorCountBySubnet[a.subnetId] : undefined) ?? a.validatorCount ?? 0;
+        const validatorsB = (b.subnetId ? validatorCountBySubnet[b.subnetId] : undefined) ?? b.validatorCount ?? 0;
         return order * (validatorsA - validatorsB);
 
       case "nativeToken":
@@ -190,9 +203,14 @@ export const ChainTableView = memo(function ChainTableView({
         const icmB = icmMessageCounts[b.chainName] || 0;
         return order * (icmA - icmB);
 
+      case "feesToPChain": {
+        const feesA = a.subnetId ? (feesBySubnet[a.subnetId] ?? -1) : -1;
+        const feesB = b.subnetId ? (feesBySubnet[b.subnetId] ?? -1) : -1;
+        return order * (feesA - feesB);
+      }
+
       // Placeholder sorts for missing data
       case "networkStatus":
-      case "feesToPChain":
       case "governanceStage":
       case "riskLevel":
         return 0;
@@ -281,6 +299,9 @@ export const ChainTableView = memo(function ChainTableView({
             {sortedChains.map((chain, index) => {
               const tpsValue = formatTPS(chain.tps);
               const tpsColor = getTPSColor(tpsValue);
+              const validatorCount = (chain.subnetId ? validatorCountBySubnet[chain.subnetId] : undefined) ?? chain.validatorCount ?? 0;
+              const feesNAvax = chain.subnetId ? feesBySubnet[chain.subnetId] : undefined;
+              const feesDisplay = formatFeesAvax(feesNAvax);
 
               return (
                 <motion.tr
@@ -348,7 +369,7 @@ export const ChainTableView = memo(function ChainTableView({
                     <div className="flex items-center gap-1.5">
                       <Server className="w-3.5 h-3.5 text-muted-foreground" />
                       <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {chain.validatorCount || 0}
+                        {validatorCount}
                       </span>
                     </div>
                   </td>
@@ -394,9 +415,15 @@ export const ChainTableView = memo(function ChainTableView({
                     })()}
                   </td>
 
-                  {/* Fees to P-Chain (Monthly) - Coming Soon */}
+                  {/* Fees to P-Chain */}
                   <td className="px-3 py-3">
-                    <ComingSoonBadge />
+                    {feesNAvax !== undefined ? (
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {feesDisplay}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">N/A</span>
+                    )}
                   </td>
 
                   {/* Governance Stage - Coming Soon */}

--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -272,7 +272,7 @@ export const ChainTableView = memo(function ChainTableView({
               />
               <SortHeader
                 field="feesToPChain"
-                label="Fees to P-Chain (Monthly)"
+                label="Fees to P-Chain (Total)"
                 sortConfig={sortConfig}
                 onSort={handleSort}
               />

--- a/src/components/comparison/ChainSelector.tsx
+++ b/src/components/comparison/ChainSelector.tsx
@@ -1,0 +1,173 @@
+import { memo, useState, useMemo } from 'react';
+import { Chain } from '../../types';
+import { Search, X, CheckCircle2 } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ChainSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  chains: Chain[];
+  selectedChainIds: string[];
+  onSelectChain: (chain: Chain) => void;
+  maxChains?: number;
+}
+
+export const ChainSelector = memo(function ChainSelector({
+  isOpen,
+  onClose,
+  chains,
+  selectedChainIds,
+  onSelectChain,
+  maxChains = 4
+}: ChainSelectorProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredChains = useMemo(() => {
+    return chains.filter(chain =>
+      chain.chainName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      chain.chainId.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [chains, searchTerm]);
+
+  const isSelected = (chainId: string) => selectedChainIds.includes(chainId);
+  const canSelectMore = selectedChainIds.length < maxChains;
+
+  const handleChainClick = (chain: Chain) => {
+    if (isSelected(chain.chainId)) {
+      return;
+    }
+    if (!canSelectMore) {
+      return;
+    }
+    onSelectChain(chain);
+    setSearchTerm('');
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ scale: 0.95, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.95, opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="bg-white dark:bg-dark-800 rounded-xl shadow-2xl max-w-3xl w-full max-h-[80vh] flex flex-col"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+                Select Chains to Compare
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                {selectedChainIds.length} of {maxChains} selected
+              </p>
+            </div>
+            <motion.button
+              onClick={onClose}
+              whileHover={{ scale: 1.1 }}
+              whileTap={{ scale: 0.9 }}
+              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            >
+              <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+            </motion.button>
+          </div>
+
+          {/* Search Bar */}
+          <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <input
+                type="text"
+                placeholder="Search chains..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-dark-900 text-gray-900 dark:text-white placeholder-gray-500 transition-all focus:outline-none focus:ring-2 focus:ring-[#ef4444]/20 focus:border-[#ef4444]"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          {/* Chain Grid */}
+          <div className="flex-1 overflow-y-auto p-6">
+            {filteredChains.length === 0 ? (
+              <div className="text-center py-12">
+                <p className="text-gray-500 dark:text-gray-400">
+                  No chains found matching "{searchTerm}"
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {filteredChains.map((chain) => {
+                  const selected = isSelected(chain.chainId);
+                  const disabled = !selected && !canSelectMore;
+
+                  return (
+                    <motion.button
+                      key={chain.chainId}
+                      onClick={() => handleChainClick(chain)}
+                      disabled={disabled}
+                      whileHover={!disabled ? { scale: 1.02 } : {}}
+                      whileTap={!disabled ? { scale: 0.98 } : {}}
+                      className={`flex items-center gap-3 p-4 rounded-lg border transition-all text-left ${
+                        selected
+                          ? 'bg-[#ef4444]/10 border-[#ef4444] cursor-default'
+                          : disabled
+                          ? 'bg-gray-50 dark:bg-dark-900/50 border-gray-200 dark:border-gray-700 opacity-50 cursor-not-allowed'
+                          : 'bg-white dark:bg-dark-900 border-gray-200 dark:border-gray-700 hover:border-[#ef4444]/50 hover:bg-gray-50 dark:hover:bg-dark-900/80'
+                      }`}
+                    >
+                      {chain.chainLogoUri ? (
+                        <img
+                          src={chain.chainLogoUri}
+                          alt={`${chain.chainName} logo`}
+                          className="w-10 h-10 rounded-lg shadow-sm flex-shrink-0"
+                          onError={(e) => {
+                            e.currentTarget.src = "/icon-dark-animated.svg";
+                            e.currentTarget.onerror = null;
+                          }}
+                        />
+                      ) : (
+                        <img
+                          src="/icon-dark-animated.svg"
+                          alt={`${chain.chainName} logo`}
+                          className="w-10 h-10 rounded-lg shadow-sm flex-shrink-0"
+                        />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-semibold text-gray-900 dark:text-white truncate">
+                          {chain.chainName}
+                        </h3>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          {chain.validatorCount || 0} validators
+                        </p>
+                      </div>
+                      {selected && (
+                        <motion.div
+                          initial={{ scale: 0 }}
+                          animate={{ scale: 1 }}
+                          transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                        >
+                          <CheckCircle2 className="w-6 h-6 text-[#ef4444] flex-shrink-0" />
+                        </motion.div>
+                      )}
+                    </motion.button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+});

--- a/src/components/comparison/ChainSelector.tsx
+++ b/src/components/comparison/ChainSelector.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useMemo } from 'react';
 import { Chain } from '../../types';
-import { Search, X, CheckCircle2 } from 'lucide-react';
+import { Search, X, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 interface ChainSelectorProps {
@@ -33,12 +33,7 @@ export const ChainSelector = memo(function ChainSelector({
   const canSelectMore = selectedChainIds.length < maxChains;
 
   const handleChainClick = (chain: Chain) => {
-    if (isSelected(chain.chainId)) {
-      return;
-    }
-    if (!canSelectMore) {
-      return;
-    }
+    if (isSelected(chain.chainId) || !canSelectMore) return;
     onSelectChain(chain);
     setSearchTerm('');
   };
@@ -51,115 +46,125 @@ export const ChainSelector = memo(function ChainSelector({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-md"
         onClick={onClose}
       >
         <motion.div
-          initial={{ scale: 0.95, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          exit={{ scale: 0.95, opacity: 0 }}
-          transition={{ duration: 0.2 }}
-          className="bg-white dark:bg-dark-800 rounded-xl shadow-2xl max-w-3xl w-full max-h-[80vh] flex flex-col"
+          initial={{ scale: 0.95, opacity: 0, y: 20 }}
+          animate={{ scale: 1, opacity: 1, y: 0 }}
+          exit={{ scale: 0.95, opacity: 0, y: 20 }}
+          transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+          className="bg-card border border-border rounded-2xl w-full max-w-2xl max-h-[80vh] flex flex-col overflow-hidden"
+          style={{ boxShadow: 'var(--card-shadow)' }}
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-border">
             <div>
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-                Select Chains to Compare
+              <h2 className="text-lg font-semibold text-foreground">
+                Select Chains
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                {selectedChainIds.length} of {maxChains} selected
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {selectedChainIds.length}/{maxChains} selected
               </p>
             </div>
             <motion.button
               onClick={onClose}
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.9 }}
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="p-2 rounded-lg hover:bg-muted transition-colors"
             >
-              <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+              <X className="w-5 h-5 text-muted-foreground" />
             </motion.button>
           </div>
 
-          {/* Search Bar */}
-          <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+          {/* Search */}
+          <div className="px-6 pt-4 pb-3">
+            <div className="relative group/search">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60 group-focus-within/search:text-[#ef4444] transition-colors pointer-events-none" />
               <input
                 type="text"
                 placeholder="Search chains..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-dark-900 text-gray-900 dark:text-white placeholder-gray-500 transition-all focus:outline-none focus:ring-2 focus:ring-[#ef4444]/20 focus:border-[#ef4444]"
+                style={{ color: 'var(--foreground)' }}
+                className="w-full pl-10 pr-10 py-2.5 text-sm rounded-xl bg-white dark:bg-[#2c2c2e] border border-border placeholder-gray-400 dark:placeholder-gray-500 transition-all focus:outline-none focus:bg-white dark:focus:bg-[#2c2c2e] focus:border-[#ef4444]/40 focus:shadow-[0_0_0_3px_rgba(239,68,68,0.08)]"
                 autoFocus
               />
+              {searchTerm && (
+                <button
+                  onClick={() => setSearchTerm('')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              )}
             </div>
           </div>
 
-          {/* Chain Grid */}
-          <div className="flex-1 overflow-y-auto p-6">
+          {/* Icon Grid */}
+          <div className="flex-1 overflow-y-auto overflow-x-hidden px-6 pb-6 scrollbar-hide">
             {filteredChains.length === 0 ? (
-              <div className="text-center py-12">
-                <p className="text-gray-500 dark:text-gray-400">
-                  No chains found matching "{searchTerm}"
-                </p>
+              <div className="flex flex-col items-center justify-center py-12">
+                <Search className="w-12 h-12 text-muted-foreground/30 mb-3" />
+                <p className="text-sm text-muted-foreground">No chains found</p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {filteredChains.map((chain) => {
+              <div className="grid grid-cols-5 sm:grid-cols-7 md:grid-cols-9 gap-3 pt-10">
+                {filteredChains.map((chain, index) => {
                   const selected = isSelected(chain.chainId);
                   const disabled = !selected && !canSelectMore;
+                  const logoSrc = chain.chainLogoUri || '/icon-dark-animated.svg';
 
                   return (
                     <motion.button
                       key={chain.chainId}
                       onClick={() => handleChainClick(chain)}
                       disabled={disabled}
-                      whileHover={!disabled ? { scale: 1.02 } : {}}
-                      whileTap={!disabled ? { scale: 0.98 } : {}}
-                      className={`flex items-center gap-3 p-4 rounded-lg border transition-all text-left ${
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ delay: index * 0.01, duration: 0.15 }}
+                      whileHover={!disabled && !selected ? { scale: 1.08, y: -2 } : {}}
+                      whileTap={!disabled && !selected ? { scale: 0.95 } : {}}
+                      className={`group relative aspect-square rounded-xl border flex items-center justify-center transition-all duration-200 ${
                         selected
-                          ? 'bg-[#ef4444]/10 border-[#ef4444] cursor-default'
+                          ? 'border-[#ef4444] bg-[#ef4444]/10 shadow-lg shadow-[#ef4444]/20'
                           : disabled
-                          ? 'bg-gray-50 dark:bg-dark-900/50 border-gray-200 dark:border-gray-700 opacity-50 cursor-not-allowed'
-                          : 'bg-white dark:bg-dark-900 border-gray-200 dark:border-gray-700 hover:border-[#ef4444]/50 hover:bg-gray-50 dark:hover:bg-dark-900/80'
+                          ? 'border-border bg-muted/30 opacity-30 cursor-not-allowed'
+                          : 'border-border bg-muted/40 hover:border-[#ef4444]/50 hover:bg-muted/70 hover:shadow-md'
                       }`}
                     >
-                      {chain.chainLogoUri ? (
-                        <img
-                          src={chain.chainLogoUri}
-                          alt={`${chain.chainName} logo`}
-                          className="w-10 h-10 rounded-lg shadow-sm flex-shrink-0"
-                          onError={(e) => {
-                            e.currentTarget.src = "/icon-dark-animated.svg";
-                            e.currentTarget.onerror = null;
-                          }}
-                        />
-                      ) : (
-                        <img
-                          src="/icon-dark-animated.svg"
-                          alt={`${chain.chainName} logo`}
-                          className="w-10 h-10 rounded-lg shadow-sm flex-shrink-0"
-                        />
-                      )}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-semibold text-gray-900 dark:text-white truncate">
-                          {chain.chainName}
-                        </h3>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
-                          {chain.validatorCount || 0} validators
-                        </p>
-                      </div>
+                      <img
+                        src={logoSrc}
+                        alt={chain.chainName}
+                        className={`w-8 h-8 rounded-lg transition-transform duration-200 ${
+                          selected ? 'scale-100' : 'group-hover:scale-110'
+                        }`}
+                        onError={(e) => {
+                          e.currentTarget.src = '/icon-dark-animated.svg';
+                          e.currentTarget.onerror = null;
+                        }}
+                      />
+
+                      {/* Selected checkmark badge */}
                       {selected && (
                         <motion.div
-                          initial={{ scale: 0 }}
-                          animate={{ scale: 1 }}
-                          transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                          initial={{ scale: 0, rotate: -180 }}
+                          animate={{ scale: 1, rotate: 0 }}
+                          transition={{ type: 'spring', stiffness: 500, damping: 25 }}
+                          className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-[#ef4444] rounded-full flex items-center justify-center shadow-lg"
                         >
-                          <CheckCircle2 className="w-6 h-6 text-[#ef4444] flex-shrink-0" />
+                          <Check className="w-3 h-3 text-white" strokeWidth={3} />
                         </motion.div>
                       )}
+
+                      {/* Hover tooltip */}
+                      <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2.5 py-1.5 rounded-lg bg-foreground text-background text-xs font-medium whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-50 shadow-lg">
+                        {chain.chainName}
+                        <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
+                          <div className="w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-foreground"></div>
+                        </div>
+                      </div>
                     </motion.button>
                   );
                 })}

--- a/src/components/comparison/ChainSelector.tsx
+++ b/src/components/comparison/ChainSelector.tsx
@@ -39,11 +39,9 @@ export const ChainSelector = memo(function ChainSelector({
     setSearchTerm('');
   };
 
-  if (!isOpen) return null;
-
   return createPortal(
     <AnimatePresence>
-      <motion.div
+      {isOpen && <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -173,7 +171,7 @@ export const ChainSelector = memo(function ChainSelector({
             )}
           </div>
         </motion.div>
-      </motion.div>
+      </motion.div>}
     </AnimatePresence>,
     document.body
   );

--- a/src/components/comparison/ChainSelector.tsx
+++ b/src/components/comparison/ChainSelector.tsx
@@ -1,4 +1,5 @@
 import { memo, useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { Chain } from '../../types';
 import { Search, X, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -40,7 +41,7 @@ export const ChainSelector = memo(function ChainSelector({
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
         initial={{ opacity: 0 }}
@@ -173,6 +174,7 @@ export const ChainSelector = memo(function ChainSelector({
           </div>
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 });

--- a/src/components/comparison/ComparisonChart.tsx
+++ b/src/components/comparison/ComparisonChart.tsx
@@ -1,0 +1,254 @@
+import { memo, useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+import { format } from 'date-fns';
+import { TPSHistory, CumulativeTxCount, DailyTxCount } from '../../types';
+import { useTheme } from '../../hooks/useTheme';
+import { AlertTriangle } from 'lucide-react';
+import { LoadingSpinner } from '../LoadingSpinner';
+
+interface ChainComparisonData {
+  chain: {
+    chainId: string;
+    chainName: string;
+    chainLogoUri?: string;
+  };
+  tpsHistory: TPSHistory[];
+  cumulativeTx: CumulativeTxCount[];
+  dailyTxCount: DailyTxCount[];
+  loading: boolean;
+}
+
+interface ComparisonChartProps {
+  comparisonChains: ChainComparisonData[];
+  metricType: 'tps' | 'transactions' | 'dailyTransactions';
+  title: string;
+  valueLabel: string;
+}
+
+const CHAIN_COLORS = [
+  { line: 'rgb(99, 102, 241)', fill: 'rgba(99, 102, 241, 0.1)' },   // Indigo
+  { line: 'rgb(16, 185, 129)', fill: 'rgba(16, 185, 129, 0.1)' },   // Emerald
+  { line: 'rgb(245, 158, 11)', fill: 'rgba(245, 158, 11, 0.1)' },   // Amber
+  { line: 'rgb(239, 68, 68)', fill: 'rgba(239, 68, 68, 0.1)' },     // Red
+];
+
+export const ComparisonChart = memo(function ComparisonChart({
+  comparisonChains,
+  metricType,
+  title,
+  valueLabel
+}: ComparisonChartProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const isLoading = comparisonChains.some(c => c.loading);
+
+  const chartData = useMemo(() => {
+    // Find all unique timestamps across all chains
+    const allTimestamps = new Set<number>();
+    comparisonChains.forEach(data => {
+      let dataPoints: { timestamp: number }[];
+      if (metricType === 'tps') {
+        dataPoints = data.tpsHistory;
+      } else if (metricType === 'dailyTransactions') {
+        dataPoints = data.dailyTxCount;
+      } else {
+        dataPoints = data.cumulativeTx;
+      }
+      dataPoints.forEach(item => allTimestamps.add(item.timestamp));
+    });
+
+    const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+    const labels = sortedTimestamps.map(ts => format(new Date(ts * 1000), 'MMM d'));
+
+    const datasets = comparisonChains.map((data, index) => {
+      const color = CHAIN_COLORS[index % CHAIN_COLORS.length];
+      let dataPoints: { timestamp: number; value?: number; totalTps?: number }[];
+      if (metricType === 'tps') {
+        dataPoints = data.tpsHistory;
+      } else if (metricType === 'dailyTransactions') {
+        dataPoints = data.dailyTxCount;
+      } else {
+        dataPoints = data.cumulativeTx;
+      }
+
+      // Create a map for quick lookup
+      const dataMap = new Map(
+        dataPoints.map(item => [
+          item.timestamp,
+          metricType === 'tps' ? (item as TPSHistory).totalTps : (item as CumulativeTxCount | DailyTxCount).value
+        ])
+      );
+
+      // Map timestamps to values, using null for missing data
+      const chartValues = sortedTimestamps.map(ts => dataMap.get(ts) ?? null);
+
+      return {
+        label: data.chain.chainName,
+        data: chartValues,
+        borderColor: color.line,
+        backgroundColor: 'transparent',
+        borderWidth: isDark ? 2.5 : 2,
+        tension: 0.35,
+        pointRadius: 0,
+        pointHoverRadius: 7,
+        pointHoverBackgroundColor: isDark ? '#1e293b' : '#ffffff',
+        pointHoverBorderColor: color.line,
+        pointHoverBorderWidth: 2.5,
+        fill: false,
+        spanGaps: true
+      };
+    });
+
+    return { labels, datasets };
+  }, [comparisonChains, metricType, isDark]);
+
+  const options = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'top' as const,
+        labels: {
+          color: isDark ? '#e2e8f0' : '#334155',
+          padding: 16,
+          font: {
+            size: 13,
+            weight: '500' as const
+          },
+          usePointStyle: true,
+          pointStyle: 'circle'
+        }
+      },
+      tooltip: {
+        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.98)',
+        titleColor: isDark ? '#f1f5f9' : '#0f172a',
+        bodyColor: isDark ? '#e2e8f0' : '#334155',
+        borderColor: isDark ? 'rgba(148, 163, 184, 0.2)' : 'rgba(148, 163, 184, 0.3)',
+        borderWidth: 1,
+        padding: 16,
+        boxPadding: 8,
+        cornerRadius: 12,
+        titleFont: {
+          size: 15,
+          weight: 'bold' as const,
+        },
+        bodyFont: {
+          size: 14,
+        },
+        bodySpacing: 6,
+        titleMarginBottom: 10,
+        displayColors: true,
+        usePointStyle: true,
+        caretSize: 8,
+        caretPadding: 12,
+        callbacks: {
+          label: (context: { dataset: { label?: string }; parsed: { y: number | null } }) => {
+            const label = context.dataset.label || '';
+            const value = context.parsed.y;
+            if (value === null) return `${label}: No data`;
+            if (metricType === 'tps') {
+              return `${label}: ${value.toFixed(2)} ${valueLabel}`;
+            }
+            return `${label}: ${value.toLocaleString()} ${valueLabel}`;
+          }
+        }
+      },
+    },
+    scales: {
+      x: {
+        grid: {
+          display: false,
+        },
+        border: {
+          display: false,
+        },
+        ticks: {
+          color: isDark ? '#94a3b8' : '#64748b',
+          font: {
+            size: 11,
+          },
+          maxRotation: 0,
+        },
+      },
+      y: {
+        beginAtZero: true,
+        border: {
+          display: false,
+        },
+        grid: {
+          color: isDark ? 'rgba(148, 163, 184, 0.08)' : 'rgba(0, 0, 0, 0.04)',
+          drawBorder: false,
+        },
+        ticks: {
+          color: isDark ? '#94a3b8' : '#64748b',
+          font: {
+            size: 11,
+          },
+          callback: (value: string | number) => {
+            const num = Number(value);
+            if (metricType === 'tps') {
+              return num.toFixed(2);
+            }
+            if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+            if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+            return num.toLocaleString();
+          },
+          padding: 8,
+        },
+      },
+    },
+  }), [isDark, metricType, valueLabel]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-card border border-border rounded-xl shadow-md p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">{title}</h3>
+        <div className="h-[400px] flex flex-col items-center justify-center">
+          <LoadingSpinner size="lg" />
+          <p className="mt-4 text-muted-foreground">Loading chart data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const hasData = comparisonChains.some(c => {
+    let dataPoints: { timestamp: number }[];
+    if (metricType === 'tps') {
+      dataPoints = c.tpsHistory;
+    } else if (metricType === 'dailyTransactions') {
+      dataPoints = c.dailyTxCount;
+    } else {
+      dataPoints = c.cumulativeTx;
+    }
+    return dataPoints.length > 0;
+  });
+
+  if (!hasData) {
+    return (
+      <div className="bg-card border border-border rounded-xl shadow-md p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">{title}</h3>
+        <div className="h-[400px] flex flex-col items-center justify-center">
+          <AlertTriangle className="h-12 w-12 text-muted-foreground/50 mb-4" />
+          <p className="text-muted-foreground text-center">
+            No data available for comparison
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card border border-border rounded-xl shadow-md p-6">
+      <h3 className="text-lg font-semibold text-foreground mb-4">{title}</h3>
+      <div className="h-[400px]">
+        <Line data={chartData} options={options} />
+      </div>
+    </div>
+  );
+});

--- a/src/components/comparison/ComparisonMetricsTable.tsx
+++ b/src/components/comparison/ComparisonMetricsTable.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo } from 'react';
 import { Chain, TPSHistory, CumulativeTxCount, DailyTxCount } from '../../types';
-import { Activity, Server, TrendingUp, Loader2, BarChart3 } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { Activity, Server, Loader2, BarChart3 } from 'lucide-react';
 
 interface ChainComparisonData {
   chain: Chain;
@@ -20,16 +19,22 @@ export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
 }: ComparisonMetricsTableProps) {
   const metrics = useMemo(() => {
     const chains = comparisonChains.map(data => {
-      const tpsValue = data.chain.tps?.value || 0;
+      // Compute latest TPS from history since /chains endpoint doesn't include it
+      const latestTps = data.tpsHistory.length > 0
+        ? data.tpsHistory[data.tpsHistory.length - 1].totalTps
+        : (data.chain.tps?.value || 0);
       const validatorCount = data.chain.validatorCount || 0;
-      const cumulativeTxValue = data.chain.cumulativeTxCount?.value || 0;
+      // Compute cumulative tx from history since /chains endpoint doesn't include it
+      const latestCumulativeTx = data.cumulativeTx.length > 0
+        ? data.cumulativeTx[data.cumulativeTx.length - 1].value
+        : (data.chain.cumulativeTxCount?.value || 0);
 
       return {
         chainId: data.chain.chainId,
         chainName: data.chain.chainName,
-        tps: tpsValue,
+        tps: latestTps,
         validators: validatorCount,
-        cumulativeTx: cumulativeTxValue,
+        cumulativeTx: latestCumulativeTx,
         loading: data.loading
       };
     });
@@ -106,26 +111,15 @@ export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
                     {chain.loading ? (
                       <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
                     ) : (
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={`text-lg font-bold ${
-                            best
-                              ? 'text-green-600 dark:text-green-400'
-                              : 'text-foreground'
-                          }`}
-                        >
-                          {formatTPS(chain.tps)}
-                        </span>
-                        {best && (
-                          <motion.div
-                            initial={{ scale: 0 }}
-                            animate={{ scale: 1 }}
-                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                          >
-                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
-                          </motion.div>
-                        )}
-                      </div>
+                      <span
+                        className={`text-lg font-bold ${
+                          best
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-foreground'
+                        }`}
+                      >
+                        {formatTPS(chain.tps)}
+                      </span>
                     )}
                   </td>
                 );
@@ -147,26 +141,15 @@ export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
                     {chain.loading ? (
                       <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
                     ) : (
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={`text-lg font-bold ${
-                            best
-                              ? 'text-green-600 dark:text-green-400'
-                              : 'text-foreground'
-                          }`}
-                        >
-                          {chain.validators}
-                        </span>
-                        {best && (
-                          <motion.div
-                            initial={{ scale: 0 }}
-                            animate={{ scale: 1 }}
-                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                          >
-                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
-                          </motion.div>
-                        )}
-                      </div>
+                      <span
+                        className={`text-lg font-bold ${
+                          best
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-foreground'
+                        }`}
+                      >
+                        {chain.validators}
+                      </span>
                     )}
                   </td>
                 );
@@ -190,26 +173,15 @@ export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
                     ) : chain.cumulativeTx === 0 ? (
                       <span className="text-sm text-muted-foreground">N/A</span>
                     ) : (
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={`text-lg font-bold ${
-                            best
-                              ? 'text-green-600 dark:text-green-400'
-                              : 'text-foreground'
-                          }`}
-                        >
-                          {formatCumulativeTx(chain.cumulativeTx)}
-                        </span>
-                        {best && (
-                          <motion.div
-                            initial={{ scale: 0 }}
-                            animate={{ scale: 1 }}
-                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                          >
-                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
-                          </motion.div>
-                        )}
-                      </div>
+                      <span
+                        className={`text-lg font-bold ${
+                          best
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-foreground'
+                        }`}
+                      >
+                        {formatCumulativeTx(chain.cumulativeTx)}
+                      </span>
                     )}
                   </td>
                 );

--- a/src/components/comparison/ComparisonMetricsTable.tsx
+++ b/src/components/comparison/ComparisonMetricsTable.tsx
@@ -1,0 +1,223 @@
+import { memo, useMemo } from 'react';
+import { Chain, TPSHistory, CumulativeTxCount, DailyTxCount } from '../../types';
+import { Activity, Server, TrendingUp, Loader2, BarChart3 } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface ChainComparisonData {
+  chain: Chain;
+  tpsHistory: TPSHistory[];
+  cumulativeTx: CumulativeTxCount[];
+  dailyTxCount: DailyTxCount[];
+  loading: boolean;
+}
+
+interface ComparisonMetricsTableProps {
+  comparisonChains: ChainComparisonData[];
+}
+
+export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
+  comparisonChains
+}: ComparisonMetricsTableProps) {
+  const metrics = useMemo(() => {
+    const chains = comparisonChains.map(data => {
+      const tpsValue = data.chain.tps?.value || 0;
+      const validatorCount = data.chain.validatorCount || 0;
+      const cumulativeTxValue = data.chain.cumulativeTxCount?.value || 0;
+
+      return {
+        chainId: data.chain.chainId,
+        chainName: data.chain.chainName,
+        tps: tpsValue,
+        validators: validatorCount,
+        cumulativeTx: cumulativeTxValue,
+        loading: data.loading
+      };
+    });
+
+    const maxTps = Math.max(...chains.map(c => c.tps));
+    const maxValidators = Math.max(...chains.map(c => c.validators));
+    const maxCumulativeTx = Math.max(...chains.map(c => c.cumulativeTx));
+
+    return {
+      chains,
+      best: { maxTps, maxValidators, maxCumulativeTx }
+    };
+  }, [comparisonChains]);
+
+  const formatTPS = (tps: number) => {
+    if (tps < 0.6) return '< 1.0';
+    return tps.toFixed(2);
+  };
+
+  const formatCumulativeTx = (value: number) => {
+    if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return value.toLocaleString();
+  };
+
+  const isBest = (value: number, max: number) => value > 0 && value === max;
+
+  return (
+    <div className="bg-card border border-border rounded-xl overflow-hidden shadow-sm">
+      <div className="p-6 border-b border-border bg-muted/20">
+        <h3 className="text-lg font-semibold text-foreground">
+          Performance Metrics
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Best values highlighted in green
+        </p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border">
+          <thead className="bg-muted/20">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Metric
+              </th>
+              {metrics.chains.map((chain) => (
+                <th
+                  key={chain.chainId}
+                  className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="truncate max-w-[150px]" title={chain.chainName}>
+                      {chain.chainName}
+                    </span>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-card divide-y divide-border">
+            {/* TPS Row */}
+            <tr className="hover:bg-muted/30 transition-colors">
+              <td className="px-6 py-4 whitespace-nowrap">
+                <div className="flex items-center gap-2">
+                  <Activity className="w-4 h-4 text-[#ef4444]" />
+                  <span className="text-sm font-medium text-foreground">TPS</span>
+                </div>
+              </td>
+              {metrics.chains.map((chain) => {
+                const best = isBest(chain.tps, metrics.best.maxTps);
+                return (
+                  <td key={chain.chainId} className="px-6 py-4 whitespace-nowrap">
+                    {chain.loading ? (
+                      <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`text-lg font-bold ${
+                            best
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-foreground'
+                          }`}
+                        >
+                          {formatTPS(chain.tps)}
+                        </span>
+                        {best && (
+                          <motion.div
+                            initial={{ scale: 0 }}
+                            animate={{ scale: 1 }}
+                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                          >
+                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
+                          </motion.div>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+
+            {/* Validators Row */}
+            <tr className="hover:bg-muted/30 transition-colors">
+              <td className="px-6 py-4 whitespace-nowrap">
+                <div className="flex items-center gap-2">
+                  <Server className="w-4 h-4 text-[#ef4444]" />
+                  <span className="text-sm font-medium text-foreground">Validators</span>
+                </div>
+              </td>
+              {metrics.chains.map((chain) => {
+                const best = isBest(chain.validators, metrics.best.maxValidators);
+                return (
+                  <td key={chain.chainId} className="px-6 py-4 whitespace-nowrap">
+                    {chain.loading ? (
+                      <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`text-lg font-bold ${
+                            best
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-foreground'
+                          }`}
+                        >
+                          {chain.validators}
+                        </span>
+                        {best && (
+                          <motion.div
+                            initial={{ scale: 0 }}
+                            animate={{ scale: 1 }}
+                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                          >
+                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
+                          </motion.div>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+
+            {/* Cumulative Transactions Row */}
+            <tr className="hover:bg-muted/30 transition-colors">
+              <td className="px-6 py-4 whitespace-nowrap">
+                <div className="flex items-center gap-2">
+                  <BarChart3 className="w-4 h-4 text-[#ef4444]" />
+                  <span className="text-sm font-medium text-foreground">Total Transactions</span>
+                </div>
+              </td>
+              {metrics.chains.map((chain) => {
+                const best = isBest(chain.cumulativeTx, metrics.best.maxCumulativeTx);
+                return (
+                  <td key={chain.chainId} className="px-6 py-4 whitespace-nowrap">
+                    {chain.loading ? (
+                      <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+                    ) : chain.cumulativeTx === 0 ? (
+                      <span className="text-sm text-muted-foreground">N/A</span>
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`text-lg font-bold ${
+                            best
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-foreground'
+                          }`}
+                        >
+                          {formatCumulativeTx(chain.cumulativeTx)}
+                        </span>
+                        {best && (
+                          <motion.div
+                            initial={{ scale: 0 }}
+                            animate={{ scale: 1 }}
+                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                          >
+                            <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
+                          </motion.div>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+});

--- a/src/components/comparison/ComparisonMetricsTable.tsx
+++ b/src/components/comparison/ComparisonMetricsTable.tsx
@@ -16,17 +16,19 @@ interface ChainComparisonData {
 
 interface ComparisonMetricsTableProps {
   comparisonChains: ChainComparisonData[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
-  comparisonChains
+  comparisonChains,
+  validatorCountBySubnet = {}
 }: ComparisonMetricsTableProps) {
   const metrics = useMemo(() => {
     const chains = comparisonChains.map(data => {
       const latestMaxTps = data.maxTPS.length > 0
         ? data.maxTPS[data.maxTPS.length - 1].value
         : 0;
-      const validatorCount = data.chain.validatorCount || 0;
+      const validatorCount = (data.chain.subnetId ? validatorCountBySubnet[data.chain.subnetId] : undefined) ?? data.chain.validatorCount ?? 0;
       const latestDailyTx = data.dailyTxCount.length > 0
         ? data.dailyTxCount[data.dailyTxCount.length - 1].value
         : 0;

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -1,0 +1,478 @@
+import { memo, useState, useEffect, useCallback, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Chain, TPSHistory, CumulativeTxCount, DailyTxCount } from '../../types';
+import { Plus, X, Trash2, BarChart3, Share2 } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChainSelector } from './ChainSelector';
+import { ComparisonMetricsTable } from './ComparisonMetricsTable';
+import { ComparisonChart } from './ComparisonChart';
+import { getTPSHistory, getCumulativeTxCount, getChainTxCountHistory, getChains } from '../../api';
+import { LoadingSpinner } from '../LoadingSpinner';
+
+interface ComparisonViewProps {
+  currentChain?: Chain;
+  availableChains?: Chain[];
+}
+
+interface ChainComparisonData {
+  chain: Chain;
+  tpsHistory: TPSHistory[];
+  cumulativeTx: CumulativeTxCount[];
+  dailyTxCount: DailyTxCount[];
+  loading: boolean;
+}
+
+export const ComparisonView = memo(function ComparisonView({
+  currentChain,
+  availableChains: providedChains
+}: ComparisonViewProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [comparisonChains, setComparisonChains] = useState<ChainComparisonData[]>([]);
+  const [availableChains, setAvailableChains] = useState<Chain[]>(providedChains || []);
+  const [chainsLoading, setChainsLoading] = useState(!providedChains);
+  const [urlInitialized, setUrlInitialized] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Read timeframe from URL or default to 7
+  const timeframeParam = searchParams.get('timeframe');
+  const timeframe = (timeframeParam === '30' ? 30 : 7) as 7 | 30;
+
+  // Update URL with current state
+  const updateUrl = useCallback((chainIds: string[], newTimeframe?: number) => {
+    const newParams = new URLSearchParams(searchParams);
+
+    if (chainIds.length > 0) {
+      newParams.set('compare', chainIds.join(','));
+    } else {
+      newParams.delete('compare');
+    }
+
+    if (newTimeframe) {
+      newParams.set('timeframe', String(newTimeframe));
+    }
+
+    setSearchParams(newParams, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  // Handle timeframe change
+  const handleTimeframeChange = useCallback((newTimeframe: 7 | 30) => {
+    const chainIds = comparisonChains.map(c => c.chain.chainId);
+    updateUrl(chainIds, newTimeframe);
+  }, [comparisonChains, updateUrl]);
+
+  // Copy share URL to clipboard
+  const handleCopyShareUrl = useCallback(() => {
+    const url = window.location.href;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
+
+  // Fetch available chains if not provided
+  useEffect(() => {
+    if (providedChains) {
+      setAvailableChains(providedChains);
+      setChainsLoading(false);
+      return;
+    }
+
+    async function fetchAvailableChains() {
+      setChainsLoading(true);
+      try {
+        const chains = await getChains();
+        // Filter to show chains with validators or Avalanche chains
+        const filteredChains = chains.filter(chain =>
+          (chain.validatorCount && chain.validatorCount >= 1) ||
+          chain.chainName.toLowerCase().includes('avalanche') ||
+          chain.chainName.toLowerCase().includes('c-chain')
+        );
+        // Exclude X-Chain and P-Chain
+        const excludedChains = filteredChains.filter(chain => {
+          const name = chain.chainName.toLowerCase();
+          return !name.includes('x-chain') && !name.includes('p-chain');
+        });
+        // Sort: C-Chain first, then alphabetically
+        const sortedChains = excludedChains.sort((a, b) => {
+          const nameA = a.chainName.toLowerCase();
+          const nameB = b.chainName.toLowerCase();
+          const isCChainA = nameA.includes('c-chain');
+          const isCChainB = nameB.includes('c-chain');
+          if (isCChainA && !isCChainB) return -1;
+          if (!isCChainA && isCChainB) return 1;
+          return a.chainName.localeCompare(b.chainName);
+        });
+        setAvailableChains(sortedChains);
+      } catch (error) {
+        console.error('Failed to fetch chains:', error);
+      } finally {
+        setChainsLoading(false);
+      }
+    }
+
+    fetchAvailableChains();
+  }, [providedChains]);
+
+  // Define fetchChainData before using it in useEffects
+  const fetchChainData = useCallback(async (chain: Chain, index: number) => {
+    try {
+      const chainId = chain.originalChainId || chain.chainId;
+      const [tpsData, txData, dailyTxData] = await Promise.all([
+        getTPSHistory(timeframe, chainId).catch(() => []),
+        getCumulativeTxCount(chainId, timeframe).catch(() => []),
+        getChainTxCountHistory(chainId, timeframe).catch(() => [])
+      ]);
+
+      setComparisonChains(prev => {
+        const updated = [...prev];
+        updated[index] = {
+          chain,
+          tpsHistory: tpsData,
+          cumulativeTx: txData,
+          dailyTxCount: dailyTxData,
+          loading: false
+        };
+        return updated;
+      });
+    } catch (error) {
+      console.error('Failed to fetch chain data:', error);
+      setComparisonChains(prev => {
+        const updated = [...prev];
+        updated[index] = {
+          ...updated[index],
+          loading: false
+        };
+        return updated;
+      });
+    }
+  }, [timeframe]);
+
+  // Initialize comparison chains from URL params after chains are loaded
+  useEffect(() => {
+    if (chainsLoading || urlInitialized || availableChains.length === 0) return;
+
+    const compareParam = searchParams.get('compare');
+    if (compareParam) {
+      const chainIds = compareParam.split(',').filter(Boolean).slice(0, 4);
+      const initialChains: ChainComparisonData[] = [];
+
+      chainIds.forEach(chainId => {
+        const chain = availableChains.find(c => c.chainId === chainId);
+        if (chain) {
+          initialChains.push({
+            chain,
+            tpsHistory: [],
+            cumulativeTx: [],
+            dailyTxCount: [],
+            loading: true
+          });
+        }
+      });
+
+      if (initialChains.length > 0) {
+        setComparisonChains(initialChains);
+        // Fetch data for each chain
+        initialChains.forEach((data, index) => {
+          fetchChainData(data.chain, index);
+        });
+      }
+    } else if (currentChain) {
+      // No URL params, use currentChain if provided
+      setComparisonChains([{
+        chain: currentChain,
+        tpsHistory: [],
+        cumulativeTx: [],
+        dailyTxCount: [],
+        loading: true
+      }]);
+      fetchChainData(currentChain, 0);
+      updateUrl([currentChain.chainId]);
+    }
+
+    setUrlInitialized(true);
+  }, [chainsLoading, availableChains, urlInitialized, searchParams, currentChain, fetchChainData, updateUrl]);
+
+  // Track previous timeframe to detect changes
+  const prevTimeframeRef = useRef(timeframe);
+
+  // Refetch data when timeframe changes
+  useEffect(() => {
+    // Skip if timeframe hasn't actually changed
+    if (prevTimeframeRef.current === timeframe) return;
+    prevTimeframeRef.current = timeframe;
+
+    // Use functional update to get current chains without dependency
+    setComparisonChains(prev => {
+      if (prev.length === 0) return prev;
+
+      // Set all to loading
+      const updated = prev.map(c => ({ ...c, loading: true }));
+
+      // Refetch data for each chain
+      prev.forEach((data, index) => {
+        fetchChainData(data.chain, index);
+      });
+
+      return updated;
+    });
+  }, [timeframe, fetchChainData]);
+
+  const handleAddChain = (chain: Chain) => {
+    if (comparisonChains.length >= 4) return;
+    if (comparisonChains.some(c => c.chain.chainId === chain.chainId)) return;
+
+    const newIndex = comparisonChains.length;
+    const newChains = [
+      ...comparisonChains,
+      {
+        chain,
+        tpsHistory: [],
+        cumulativeTx: [],
+        dailyTxCount: [],
+        loading: true
+      }
+    ];
+    setComparisonChains(newChains);
+
+    // Update URL with new chain
+    updateUrl(newChains.map(c => c.chain.chainId));
+
+    fetchChainData(chain, newIndex);
+    setIsModalOpen(false);
+  };
+
+  const handleRemoveChain = (chainId: string) => {
+    const newChains = comparisonChains.filter(c => c.chain.chainId !== chainId);
+    setComparisonChains(newChains);
+
+    // Update URL
+    updateUrl(newChains.map(c => c.chain.chainId));
+  };
+
+  const handleClearAll = () => {
+    setComparisonChains([]);
+    // Clear URL params
+    updateUrl([]);
+  };
+
+  const selectedChainIds = comparisonChains.map(c => c.chain.chainId);
+  const canAddMore = comparisonChains.length < 4;
+  const hasMultipleChains = comparisonChains.length >= 2;
+  const hasAnyChains = comparisonChains.length > 0;
+
+  if (chainsLoading) {
+    return (
+      <div className="bg-card border border-border rounded-xl p-12 flex flex-col items-center justify-center">
+        <LoadingSpinner size="lg" />
+        <p className="mt-4 text-muted-foreground">Loading chains...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header with Actions */}
+      <div className="bg-card border border-border rounded-xl p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-bold text-foreground flex items-center gap-2">
+              <BarChart3 className="w-5 h-5 text-[#ef4444]" />
+              Chain Comparison
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {comparisonChains.length === 0
+                ? 'Select chains to compare performance metrics'
+                : comparisonChains.length === 1
+                ? 'Add more chains to compare'
+                : `Comparing ${comparisonChains.length} chains`}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {hasAnyChains && (
+              <motion.button
+                initial={{ scale: 0, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0, opacity: 0 }}
+                onClick={handleClearAll}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted transition-all"
+              >
+                <Trash2 className="w-4 h-4" />
+                Clear All
+              </motion.button>
+            )}
+
+            <motion.button
+              onClick={() => setIsModalOpen(!isModalOpen)}
+              disabled={!canAddMore}
+              whileHover={canAddMore ? { scale: 1.05 } : {}}
+              whileTap={canAddMore ? { scale: 0.95 } : {}}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+                isModalOpen
+                  ? 'bg-[#dc2626] text-white'
+                  : canAddMore
+                  ? 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
+                  : 'bg-muted text-muted-foreground cursor-not-allowed'
+              }`}
+            >
+              {isModalOpen ? <X className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+              {isModalOpen ? 'Close' : 'Add Chain'}
+            </motion.button>
+          </div>
+        </div>
+
+        {/* Selected Chains Pills */}
+        {hasAnyChains && (
+          <div className="mt-4 pt-4 border-t border-border">
+            <div className="flex flex-wrap gap-2">
+              <AnimatePresence mode="popLayout">
+                {comparisonChains.map((data, index) => (
+                  <motion.div
+                    key={data.chain.chainId}
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0, opacity: 0 }}
+                    transition={{
+                      type: "spring",
+                      stiffness: 500,
+                      damping: 30,
+                      delay: index * 0.05
+                    }}
+                    className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg border border-border"
+                  >
+                    {data.chain.chainLogoUri ? (
+                      <img
+                        src={data.chain.chainLogoUri}
+                        alt={`${data.chain.chainName} logo`}
+                        className="w-5 h-5 rounded"
+                        onError={(e) => {
+                          e.currentTarget.src = "/icon-dark-animated.svg";
+                          e.currentTarget.onerror = null;
+                        }}
+                      />
+                    ) : (
+                      <img
+                        src="/icon-dark-animated.svg"
+                        alt={`${data.chain.chainName} logo`}
+                        className="w-5 h-5 rounded"
+                      />
+                    )}
+                    <span className="text-sm font-medium text-foreground">
+                      {data.chain.chainName}
+                    </span>
+                    <motion.button
+                      onClick={() => handleRemoveChain(data.chain.chainId)}
+                      whileHover={{ scale: 1.2, rotate: 90 }}
+                      whileTap={{ scale: 0.9 }}
+                      className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors"
+                    >
+                      <X className="w-4 h-4 text-muted-foreground" />
+                    </motion.button>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Comparison Content */}
+      {hasMultipleChains ? (
+        <div className="space-y-6">
+          {/* Metrics Table */}
+          <ComparisonMetricsTable comparisonChains={comparisonChains} />
+
+          {/* Timeframe Selector and Share Button */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <div className="inline-flex items-center gap-2 p-1 bg-muted rounded-lg border border-border">
+              <button
+                onClick={() => handleTimeframeChange(7)}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
+                  timeframe === 7
+                    ? 'bg-[#ef4444] text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                7 Days
+              </button>
+              <button
+                onClick={() => handleTimeframeChange(30)}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
+                  timeframe === 30
+                    ? 'bg-[#ef4444] text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                30 Days
+              </button>
+            </div>
+
+            <motion.button
+              onClick={handleCopyShareUrl}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+            >
+              <Share2 className="w-4 h-4" />
+              {copied ? 'Copied!' : 'Share'}
+            </motion.button>
+          </div>
+
+          {/* TPS Chart */}
+          <ComparisonChart
+            comparisonChains={comparisonChains}
+            metricType="tps"
+            title="TPS Comparison"
+            valueLabel="TPS"
+          />
+
+          {/* Daily Transactions Chart */}
+          <ComparisonChart
+            comparisonChains={comparisonChains}
+            metricType="dailyTransactions"
+            title="Daily Transactions"
+            valueLabel="Transactions"
+          />
+        </div>
+      ) : (
+        <div className="bg-card border border-border rounded-xl p-12 text-center">
+          <BarChart3 className="w-16 h-16 text-muted-foreground/50 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            {comparisonChains.length === 0 ? 'Start Comparing Chains' : 'Add More Chains'}
+          </h3>
+          <p className="text-sm text-muted-foreground mb-6">
+            {comparisonChains.length === 0
+              ? 'Select at least 2 chains to compare their performance metrics side-by-side'
+              : 'Add at least one more chain to see the comparison'}
+          </p>
+          <motion.button
+            onClick={() => setIsModalOpen(!isModalOpen)}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all ${
+              isModalOpen
+                ? 'bg-[#dc2626] text-white'
+                : 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
+            }`}
+          >
+            {isModalOpen ? <X className="w-5 h-5" /> : <Plus className="w-5 h-5" />}
+            {isModalOpen ? 'Close' : comparisonChains.length === 0 ? 'Select Chains' : 'Add Another Chain'}
+          </motion.button>
+        </div>
+      )}
+
+      {/* Chain Selector Modal */}
+      <ChainSelector
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        chains={availableChains}
+        selectedChainIds={selectedChainIds}
+        onSelectChain={handleAddChain}
+        maxChains={4}
+      />
+    </div>
+  );
+});

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -1,12 +1,12 @@
 import { memo, useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Chain, TPSHistory, CumulativeTxCount, DailyTxCount } from '../../types';
-import { Plus, X, Trash2, BarChart3, Share2 } from 'lucide-react';
+import { Chain, DailyTxCount, DailyActiveAddresses, MaxTPSHistory, GasUsedHistory, AvgGasPriceHistory, FeesPaidHistory } from '../../types';
+import { Plus, X, Trash2, BarChart3, Share2, ChevronDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChainSelector } from './ChainSelector';
 import { ComparisonMetricsTable } from './ComparisonMetricsTable';
-import { ComparisonChart } from './ComparisonChart';
-import { getTPSHistory, getCumulativeTxCount, getChainTxCountHistory, getChains } from '../../api';
+import { ComparisonChart, ComparisonMetricType } from './ComparisonChart';
+import { getDailyActiveAddresses, getChainTxCountHistory, getChainMaxTPSHistory, getChainGasUsedHistory, getChainAvgGasPriceHistory, getChainFeesPaidHistory, getChains } from '../../api';
 import { LoadingSpinner } from '../LoadingSpinner';
 
 interface ComparisonViewProps {
@@ -16,11 +16,33 @@ interface ComparisonViewProps {
 
 interface ChainComparisonData {
   chain: Chain;
-  tpsHistory: TPSHistory[];
-  cumulativeTx: CumulativeTxCount[];
+  dailyActiveAddresses: DailyActiveAddresses[];
   dailyTxCount: DailyTxCount[];
+  maxTPS: MaxTPSHistory[];
+  gasUsed: GasUsedHistory[];
+  avgGasPrice: AvgGasPriceHistory[];
+  feesPaid: FeesPaidHistory[];
   loading: boolean;
 }
+
+const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; valueLabel: string }[] = [
+  { id: 'dailyActiveAddresses', name: 'Daily Active Addresses', valueLabel: 'addresses' },
+  { id: 'dailyTxCount', name: 'Daily Transaction Count', valueLabel: 'transactions' },
+  { id: 'maxTPS', name: 'Daily Max TPS', valueLabel: 'TPS' },
+  { id: 'gasUsed', name: 'Daily Gas Used', valueLabel: 'gas' },
+  { id: 'avgGasPrice', name: 'Daily Avg Gas Price', valueLabel: '' },
+  { id: 'feesPaid', name: 'Daily Fees Paid', valueLabel: '' },
+];
+
+const stagger = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.25, 0.1, 0.25, 1] } },
+};
 
 export const ComparisonView = memo(function ComparisonView({
   currentChain,
@@ -33,13 +55,20 @@ export const ComparisonView = memo(function ComparisonView({
   const [chainsLoading, setChainsLoading] = useState(!providedChains);
   const [urlInitialized, setUrlInitialized] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [metricDropdownOpen, setMetricDropdownOpen] = useState(false);
+
+  // Read selected metric from URL or default
+  const metricParam = searchParams.get('metric');
+  const selectedMetric: ComparisonMetricType = COMPARISON_METRICS.some(m => m.id === metricParam)
+    ? metricParam as ComparisonMetricType
+    : 'dailyActiveAddresses';
 
   // Read timeframe from URL or default to 7
   const timeframeParam = searchParams.get('timeframe');
   const timeframe = (timeframeParam === '30' ? 30 : 7) as 7 | 30;
 
   // Update URL with current state
-  const updateUrl = useCallback((chainIds: string[], newTimeframe?: number) => {
+  const updateUrl = useCallback((chainIds: string[], newTimeframe?: number, newMetric?: ComparisonMetricType) => {
     const newParams = new URLSearchParams(searchParams);
 
     if (chainIds.length > 0) {
@@ -52,6 +81,10 @@ export const ComparisonView = memo(function ComparisonView({
       newParams.set('timeframe', String(newTimeframe));
     }
 
+    if (newMetric) {
+      newParams.set('metric', newMetric);
+    }
+
     setSearchParams(newParams, { replace: true });
   }, [searchParams, setSearchParams]);
 
@@ -59,6 +92,13 @@ export const ComparisonView = memo(function ComparisonView({
   const handleTimeframeChange = useCallback((newTimeframe: 7 | 30) => {
     const chainIds = comparisonChains.map(c => c.chain.chainId);
     updateUrl(chainIds, newTimeframe);
+  }, [comparisonChains, updateUrl]);
+
+  // Handle metric change
+  const handleMetricChange = useCallback((metric: ComparisonMetricType) => {
+    const chainIds = comparisonChains.map(c => c.chain.chainId);
+    updateUrl(chainIds, undefined, metric);
+    setMetricDropdownOpen(false);
   }, [comparisonChains, updateUrl]);
 
   // Copy share URL to clipboard
@@ -82,18 +122,15 @@ export const ComparisonView = memo(function ComparisonView({
       setChainsLoading(true);
       try {
         const chains = await getChains();
-        // Filter to show chains with validators or Avalanche chains
         const filteredChains = chains.filter(chain =>
           (chain.validatorCount && chain.validatorCount >= 1) ||
           chain.chainName.toLowerCase().includes('avalanche') ||
           chain.chainName.toLowerCase().includes('c-chain')
         );
-        // Exclude X-Chain and P-Chain
         const excludedChains = filteredChains.filter(chain => {
           const name = chain.chainName.toLowerCase();
           return !name.includes('x-chain') && !name.includes('p-chain');
         });
-        // Sort: C-Chain first, then alphabetically
         const sortedChains = excludedChains.sort((a, b) => {
           const nameA = a.chainName.toLowerCase();
           const nameB = b.chainName.toLowerCase();
@@ -114,23 +151,31 @@ export const ComparisonView = memo(function ComparisonView({
     fetchAvailableChains();
   }, [providedChains]);
 
-  // Define fetchChainData before using it in useEffects
+  // Fetch all 6 metric types for a chain
   const fetchChainData = useCallback(async (chain: Chain, index: number) => {
     try {
       const chainId = chain.originalChainId || chain.chainId;
-      const [tpsData, txData, dailyTxData] = await Promise.all([
-        getTPSHistory(timeframe, chainId).catch(() => []),
-        getCumulativeTxCount(chainId, timeframe).catch(() => []),
-        getChainTxCountHistory(chainId, timeframe).catch(() => [])
+      const evmChainIdStr = chain.evmChainId ? String(chain.evmChainId) : chainId;
+
+      const [activeAddresses, dailyTx, maxTps, gasUsedData, avgGasPriceData, feesPaidData] = await Promise.all([
+        getDailyActiveAddresses(evmChainIdStr, timeframe).catch(() => []),
+        getChainTxCountHistory(chainId, timeframe).catch(() => []),
+        getChainMaxTPSHistory(chainId, timeframe).catch(() => []),
+        getChainGasUsedHistory(chainId, timeframe).catch(() => []),
+        getChainAvgGasPriceHistory(chainId, timeframe).catch(() => []),
+        getChainFeesPaidHistory(chainId, timeframe).catch(() => [])
       ]);
 
       setComparisonChains(prev => {
         const updated = [...prev];
         updated[index] = {
           chain,
-          tpsHistory: tpsData,
-          cumulativeTx: txData,
-          dailyTxCount: dailyTxData,
+          dailyActiveAddresses: activeAddresses,
+          dailyTxCount: dailyTx,
+          maxTPS: maxTps,
+          gasUsed: gasUsedData,
+          avgGasPrice: avgGasPriceData,
+          feesPaid: feesPaidData,
           loading: false
         };
         return updated;
@@ -162,9 +207,12 @@ export const ComparisonView = memo(function ComparisonView({
         if (chain) {
           initialChains.push({
             chain,
-            tpsHistory: [],
-            cumulativeTx: [],
+            dailyActiveAddresses: [],
             dailyTxCount: [],
+            maxTPS: [],
+            gasUsed: [],
+            avgGasPrice: [],
+            feesPaid: [],
             loading: true
           });
         }
@@ -172,18 +220,19 @@ export const ComparisonView = memo(function ComparisonView({
 
       if (initialChains.length > 0) {
         setComparisonChains(initialChains);
-        // Fetch data for each chain
         initialChains.forEach((data, index) => {
           fetchChainData(data.chain, index);
         });
       }
     } else if (currentChain) {
-      // No URL params, use currentChain if provided
       setComparisonChains([{
         chain: currentChain,
-        tpsHistory: [],
-        cumulativeTx: [],
+        dailyActiveAddresses: [],
         dailyTxCount: [],
+        maxTPS: [],
+        gasUsed: [],
+        avgGasPrice: [],
+        feesPaid: [],
         loading: true
       }]);
       fetchChainData(currentChain, 0);
@@ -198,18 +247,14 @@ export const ComparisonView = memo(function ComparisonView({
 
   // Refetch data when timeframe changes
   useEffect(() => {
-    // Skip if timeframe hasn't actually changed
     if (prevTimeframeRef.current === timeframe) return;
     prevTimeframeRef.current = timeframe;
 
-    // Use functional update to get current chains without dependency
     setComparisonChains(prev => {
       if (prev.length === 0) return prev;
 
-      // Set all to loading
       const updated = prev.map(c => ({ ...c, loading: true }));
 
-      // Refetch data for each chain
       prev.forEach((data, index) => {
         fetchChainData(data.chain, index);
       });
@@ -227,15 +272,17 @@ export const ComparisonView = memo(function ComparisonView({
       ...comparisonChains,
       {
         chain,
-        tpsHistory: [],
-        cumulativeTx: [],
+        dailyActiveAddresses: [],
         dailyTxCount: [],
+        maxTPS: [],
+        gasUsed: [],
+        avgGasPrice: [],
+        feesPaid: [],
         loading: true
       }
     ];
     setComparisonChains(newChains);
 
-    // Update URL with new chain
     updateUrl(newChains.map(c => c.chain.chainId));
 
     fetchChainData(chain, newIndex);
@@ -246,13 +293,11 @@ export const ComparisonView = memo(function ComparisonView({
     const newChains = comparisonChains.filter(c => c.chain.chainId !== chainId);
     setComparisonChains(newChains);
 
-    // Update URL
     updateUrl(newChains.map(c => c.chain.chainId));
   };
 
   const handleClearAll = () => {
     setComparisonChains([]);
-    // Clear URL params
     updateUrl([]);
   };
 
@@ -261,19 +306,30 @@ export const ComparisonView = memo(function ComparisonView({
   const hasMultipleChains = comparisonChains.length >= 2;
   const hasAnyChains = comparisonChains.length > 0;
 
+  const currentMetricConfig = COMPARISON_METRICS.find(m => m.id === selectedMetric) || COMPARISON_METRICS[0];
+
   if (chainsLoading) {
     return (
-      <div className="bg-card border border-border rounded-xl p-12 flex flex-col items-center justify-center">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className="bg-card border border-border rounded-xl p-12 flex flex-col items-center justify-center"
+      >
         <LoadingSpinner size="lg" />
         <p className="mt-4 text-muted-foreground">Loading chains...</p>
-      </div>
+      </motion.div>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <motion.div
+      variants={stagger}
+      initial="hidden"
+      animate="visible"
+      className="space-y-6"
+    >
       {/* Header with Actions */}
-      <div className="bg-card border border-border rounded-xl p-6">
+      <motion.div variants={fadeUp} className="bg-card border border-border rounded-xl p-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h2 className="text-xl font-bold text-foreground flex items-center gap-2">
@@ -290,20 +346,23 @@ export const ComparisonView = memo(function ComparisonView({
           </div>
 
           <div className="flex items-center gap-2">
-            {hasAnyChains && (
-              <motion.button
-                initial={{ scale: 0, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                exit={{ scale: 0, opacity: 0 }}
-                onClick={handleClearAll}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted transition-all"
-              >
-                <Trash2 className="w-4 h-4" />
-                Clear All
-              </motion.button>
-            )}
+            <AnimatePresence>
+              {hasAnyChains && (
+                <motion.button
+                  initial={{ scale: 0, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0, opacity: 0 }}
+                  transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+                  onClick={handleClearAll}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted transition-all"
+                >
+                  <Trash2 className="w-4 h-4" />
+                  Clear All
+                </motion.button>
+              )}
+            </AnimatePresence>
 
             <motion.button
               onClick={() => setIsModalOpen(!isModalOpen)}
@@ -325,144 +384,260 @@ export const ComparisonView = memo(function ComparisonView({
         </div>
 
         {/* Selected Chains Pills */}
-        {hasAnyChains && (
-          <div className="mt-4 pt-4 border-t border-border">
-            <div className="flex flex-wrap gap-2">
-              <AnimatePresence mode="popLayout">
-                {comparisonChains.map((data, index) => (
-                  <motion.div
-                    key={data.chain.chainId}
-                    initial={{ scale: 0, opacity: 0 }}
-                    animate={{ scale: 1, opacity: 1 }}
-                    exit={{ scale: 0, opacity: 0 }}
-                    transition={{
-                      type: "spring",
-                      stiffness: 500,
-                      damping: 30,
-                      delay: index * 0.05
-                    }}
-                    className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg border border-border"
-                  >
-                    {data.chain.chainLogoUri ? (
-                      <img
-                        src={data.chain.chainLogoUri}
-                        alt={`${data.chain.chainName} logo`}
-                        className="w-5 h-5 rounded"
-                        onError={(e) => {
-                          e.currentTarget.src = "/icon-dark-animated.svg";
-                          e.currentTarget.onerror = null;
+        <AnimatePresence>
+          {hasAnyChains && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
+              className="overflow-hidden"
+            >
+              <div className="mt-4 pt-4 border-t border-border">
+                <div className="flex flex-wrap gap-2">
+                  <AnimatePresence mode="popLayout">
+                    {comparisonChains.map((data, index) => (
+                      <motion.div
+                        key={data.chain.chainId}
+                        layout
+                        initial={{ scale: 0, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        exit={{ scale: 0, opacity: 0 }}
+                        transition={{
+                          type: "spring",
+                          stiffness: 500,
+                          damping: 30,
+                          delay: index * 0.05
                         }}
-                      />
-                    ) : (
-                      <img
-                        src="/icon-dark-animated.svg"
-                        alt={`${data.chain.chainName} logo`}
-                        className="w-5 h-5 rounded"
-                      />
-                    )}
-                    <span className="text-sm font-medium text-foreground">
-                      {data.chain.chainName}
-                    </span>
-                    <motion.button
-                      onClick={() => handleRemoveChain(data.chain.chainId)}
-                      whileHover={{ scale: 1.2, rotate: 90 }}
-                      whileTap={{ scale: 0.9 }}
-                      className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors"
-                    >
-                      <X className="w-4 h-4 text-muted-foreground" />
-                    </motion.button>
-                  </motion.div>
-                ))}
-              </AnimatePresence>
-            </div>
-          </div>
-        )}
-      </div>
+                        className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg border border-border"
+                      >
+                        {data.chain.chainLogoUri ? (
+                          <img
+                            src={data.chain.chainLogoUri}
+                            alt={`${data.chain.chainName} logo`}
+                            className="w-5 h-5 rounded"
+                            onError={(e) => {
+                              e.currentTarget.src = "/icon-dark-animated.svg";
+                              e.currentTarget.onerror = null;
+                            }}
+                          />
+                        ) : (
+                          <img
+                            src="/icon-dark-animated.svg"
+                            alt={`${data.chain.chainName} logo`}
+                            className="w-5 h-5 rounded"
+                          />
+                        )}
+                        <span className="text-sm font-medium text-foreground">
+                          {data.chain.chainName}
+                        </span>
+                        <motion.button
+                          onClick={() => handleRemoveChain(data.chain.chainId)}
+                          whileHover={{ scale: 1.2, rotate: 90 }}
+                          whileTap={{ scale: 0.9 }}
+                          className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors"
+                        >
+                          <X className="w-4 h-4 text-muted-foreground" />
+                        </motion.button>
+                      </motion.div>
+                    ))}
+                  </AnimatePresence>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
 
       {/* Comparison Content */}
-      {hasMultipleChains ? (
-        <div className="space-y-6">
-          {/* Metrics Table */}
-          <ComparisonMetricsTable comparisonChains={comparisonChains} />
+      <AnimatePresence mode="wait">
+        {hasMultipleChains ? (
+          <motion.div
+            key="comparison-content"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
+            className="space-y-6"
+          >
+            {/* Metrics Table */}
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, delay: 0.1 }}
+            >
+              <ComparisonMetricsTable comparisonChains={comparisonChains} />
+            </motion.div>
 
-          {/* Timeframe Selector and Share Button */}
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <div className="inline-flex items-center gap-2 p-1 bg-muted rounded-lg border border-border">
-              <button
-                onClick={() => handleTimeframeChange(7)}
-                className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                  timeframe === 7
-                    ? 'bg-[#ef4444] text-white'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                7 Days
-              </button>
-              <button
-                onClick={() => handleTimeframeChange(30)}
-                className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                  timeframe === 30
-                    ? 'bg-[#ef4444] text-white'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                30 Days
-              </button>
-            </div>
+            {/* Controls: Metric Dropdown, Timeframe, Share */}
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, delay: 0.2 }}
+              className="flex flex-col sm:flex-row items-center justify-center gap-4"
+            >
+              {/* Metric Selector Dropdown */}
+              <div className="relative">
+                <motion.button
+                  onClick={() => setMetricDropdownOpen(!metricDropdownOpen)}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className="flex items-center gap-2 px-4 py-2 bg-muted rounded-lg border border-border text-sm font-medium text-foreground hover:bg-muted/70 transition-all min-w-[220px] justify-between"
+                >
+                  <span>{currentMetricConfig.name}</span>
+                  <motion.div
+                    animate={{ rotate: metricDropdownOpen ? 180 : 0 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <ChevronDown className="w-4 h-4 text-muted-foreground" />
+                  </motion.div>
+                </motion.button>
 
+                <AnimatePresence>
+                  {metricDropdownOpen && (
+                    <motion.div
+                      initial={{ opacity: 0, y: -8, scale: 0.96 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      exit={{ opacity: 0, y: -8, scale: 0.96 }}
+                      transition={{ duration: 0.15, ease: [0.25, 0.1, 0.25, 1] }}
+                      className="absolute left-0 mt-2 w-full bg-card border border-border rounded-lg shadow-lg z-20 overflow-hidden"
+                    >
+                      {COMPARISON_METRICS.map((metric, i) => (
+                        <motion.button
+                          key={metric.id}
+                          initial={{ opacity: 0, x: -8 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: i * 0.03 }}
+                          onClick={() => handleMetricChange(metric.id)}
+                          className={`w-full px-4 py-2.5 text-left text-sm transition-colors first:rounded-t-lg last:rounded-b-lg ${
+                            selectedMetric === metric.id
+                              ? 'bg-[#ef4444]/10 text-[#ef4444] font-medium'
+                              : 'text-foreground hover:bg-muted/30'
+                          }`}
+                        >
+                          {metric.name}
+                        </motion.button>
+                      ))}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              {/* Timeframe Selector */}
+              <div className="inline-flex items-center gap-1 p-1 bg-muted rounded-lg border border-border">
+                {([7, 30] as const).map(days => (
+                  <motion.button
+                    key={days}
+                    onClick={() => handleTimeframeChange(days)}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    className={`relative px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                      timeframe === days
+                        ? 'text-white'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {timeframe === days && (
+                      <motion.div
+                        layoutId="timeframe-pill"
+                        className="absolute inset-0 bg-[#ef4444] rounded-md"
+                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                      />
+                    )}
+                    <span className="relative z-10">{days} Days</span>
+                  </motion.button>
+                ))}
+              </div>
+
+              <motion.button
+                onClick={handleCopyShareUrl}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+              >
+                <Share2 className="w-4 h-4" />
+                <AnimatePresence mode="wait">
+                  <motion.span
+                    key={copied ? 'copied' : 'share'}
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -4 }}
+                    transition={{ duration: 0.15 }}
+                  >
+                    {copied ? 'Copied!' : 'Share'}
+                  </motion.span>
+                </AnimatePresence>
+              </motion.button>
+            </motion.div>
+
+            {/* Single Comparison Chart */}
+            <motion.div
+              key={selectedMetric}
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, delay: 0.3 }}
+            >
+              <ComparisonChart
+                comparisonChains={comparisonChains}
+                metricType={selectedMetric}
+                title={currentMetricConfig.name}
+                valueLabel={currentMetricConfig.valueLabel}
+              />
+            </motion.div>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="empty-state"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
+            className="bg-card border border-border rounded-xl p-12 text-center"
+          >
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.1, type: 'spring', stiffness: 300, damping: 20 }}
+            >
+              <BarChart3 className="w-16 h-16 text-muted-foreground/50 mx-auto mb-4" />
+            </motion.div>
+            <motion.h3
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+              className="text-lg font-semibold text-foreground mb-2"
+            >
+              {comparisonChains.length === 0 ? 'Start Comparing Chains' : 'Add More Chains'}
+            </motion.h3>
+            <motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.25 }}
+              className="text-sm text-muted-foreground mb-6"
+            >
+              {comparisonChains.length === 0
+                ? 'Select at least 2 chains to compare their performance metrics side-by-side'
+                : 'Add at least one more chain to see the comparison'}
+            </motion.p>
             <motion.button
-              onClick={handleCopyShareUrl}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+              onClick={() => setIsModalOpen(!isModalOpen)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
-              className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+              className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all ${
+                isModalOpen
+                  ? 'bg-[#dc2626] text-white'
+                  : 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
+              }`}
             >
-              <Share2 className="w-4 h-4" />
-              {copied ? 'Copied!' : 'Share'}
+              {isModalOpen ? <X className="w-5 h-5" /> : <Plus className="w-5 h-5" />}
+              {isModalOpen ? 'Close' : comparisonChains.length === 0 ? 'Select Chains' : 'Add Another Chain'}
             </motion.button>
-          </div>
-
-          {/* TPS Chart */}
-          <ComparisonChart
-            comparisonChains={comparisonChains}
-            metricType="tps"
-            title="TPS Comparison"
-            valueLabel="TPS"
-          />
-
-          {/* Daily Transactions Chart */}
-          <ComparisonChart
-            comparisonChains={comparisonChains}
-            metricType="dailyTransactions"
-            title="Daily Transactions"
-            valueLabel="Transactions"
-          />
-        </div>
-      ) : (
-        <div className="bg-card border border-border rounded-xl p-12 text-center">
-          <BarChart3 className="w-16 h-16 text-muted-foreground/50 mx-auto mb-4" />
-          <h3 className="text-lg font-semibold text-foreground mb-2">
-            {comparisonChains.length === 0 ? 'Start Comparing Chains' : 'Add More Chains'}
-          </h3>
-          <p className="text-sm text-muted-foreground mb-6">
-            {comparisonChains.length === 0
-              ? 'Select at least 2 chains to compare their performance metrics side-by-side'
-              : 'Add at least one more chain to see the comparison'}
-          </p>
-          <motion.button
-            onClick={() => setIsModalOpen(!isModalOpen)}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all ${
-              isModalOpen
-                ? 'bg-[#dc2626] text-white'
-                : 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
-            }`}
-          >
-            {isModalOpen ? <X className="w-5 h-5" /> : <Plus className="w-5 h-5" />}
-            {isModalOpen ? 'Close' : comparisonChains.length === 0 ? 'Select Chains' : 'Add Another Chain'}
-          </motion.button>
-        </div>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Chain Selector Modal */}
       <ChainSelector
@@ -473,6 +648,6 @@ export const ComparisonView = memo(function ComparisonView({
         onSelectChain={handleAddChain}
         maxChains={4}
       />
-    </div>
+    </motion.div>
   );
 });

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -314,12 +314,7 @@ export const ComparisonView = memo(function ComparisonView({
   return (
     <div className="space-y-6">
       {/* Header with Actions */}
-      <motion.div
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
-        className="bg-card border border-border rounded-xl p-6"
-      >
+      <div className="bg-card border border-border rounded-xl p-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h2 className="text-xl font-bold text-foreground flex items-center gap-2">
@@ -437,7 +432,7 @@ export const ComparisonView = memo(function ComparisonView({
             </motion.div>
           )}
         </AnimatePresence>
-      </motion.div>
+      </div>
 
       {/* Comparison Content */}
       <AnimatePresence mode="wait">
@@ -576,43 +571,19 @@ export const ComparisonView = memo(function ComparisonView({
             </motion.div>
           </motion.div>
         ) : (
-          <motion.div
-            key="empty-state"
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
+          <div
             className="bg-card border border-border rounded-xl p-12 text-center"
           >
-            <motion.div
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ delay: 0.1, type: 'spring', stiffness: 300, damping: 20 }}
-            >
-              <BarChart3 className="w-16 h-16 text-muted-foreground/50 mx-auto mb-4" />
-            </motion.div>
-            <motion.h3
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
-              className="text-lg font-semibold text-foreground mb-2"
-            >
+            <BarChart3 className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+            <h3 className="text-lg font-semibold text-foreground mb-2">
               {comparisonChains.length === 0 ? 'Start Comparing Chains' : 'Add More Chains'}
-            </motion.h3>
-            <motion.p
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.25 }}
-              className="text-sm text-muted-foreground mb-6"
-            >
+            </h3>
+            <p className="text-sm text-muted-foreground mb-6">
               {comparisonChains.length === 0
                 ? 'Select at least 2 chains to compare their performance metrics side-by-side'
                 : 'Add at least one more chain to see the comparison'}
-            </motion.p>
+            </p>
             <motion.button
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3 }}
               onClick={() => setIsModalOpen(!isModalOpen)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
@@ -625,7 +596,7 @@ export const ComparisonView = memo(function ComparisonView({
               {isModalOpen ? <X className="w-5 h-5" /> : <Plus className="w-5 h-5" />}
               {isModalOpen ? 'Close' : comparisonChains.length === 0 ? 'Select Chains' : 'Add Another Chain'}
             </motion.button>
-          </motion.div>
+          </div>
         )}
       </AnimatePresence>
 

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -12,6 +12,7 @@ import { LoadingSpinner } from '../LoadingSpinner';
 interface ComparisonViewProps {
   currentChain?: Chain;
   availableChains?: Chain[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 interface ChainComparisonData {
@@ -36,7 +37,8 @@ const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; valueLabel: 
 
 export const ComparisonView = memo(function ComparisonView({
   currentChain,
-  availableChains: providedChains
+  availableChains: providedChains,
+  validatorCountBySubnet = {}
 }: ComparisonViewProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -451,7 +453,7 @@ export const ComparisonView = memo(function ComparisonView({
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.4, delay: 0.1 }}
             >
-              <ComparisonMetricsTable comparisonChains={comparisonChains} />
+              <ComparisonMetricsTable comparisonChains={comparisonChains} validatorCountBySubnet={validatorCountBySubnet} />
             </motion.div>
 
             {/* Controls: Metric Dropdown, Timeframe, Share */}

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -34,16 +34,6 @@ const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; valueLabel: 
   { id: 'feesPaid', name: 'Daily Fees Paid', valueLabel: '' },
 ];
 
-const stagger = {
-  hidden: {},
-  visible: { transition: { staggerChildren: 0.08 } },
-};
-
-const fadeUp = {
-  hidden: { opacity: 0, y: 16 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.25, 0.1, 0.25, 1] } },
-};
-
 export const ComparisonView = memo(function ComparisonView({
   currentChain,
   availableChains: providedChains
@@ -322,14 +312,14 @@ export const ComparisonView = memo(function ComparisonView({
   }
 
   return (
-    <motion.div
-      variants={stagger}
-      initial="hidden"
-      animate="visible"
-      className="space-y-6"
-    >
+    <div className="space-y-6">
       {/* Header with Actions */}
-      <motion.div variants={fadeUp} className="bg-card border border-border rounded-xl p-6">
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
+        className="bg-card border border-border rounded-xl p-6"
+      >
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h2 className="text-xl font-bold text-foreground flex items-center gap-2">
@@ -648,6 +638,6 @@ export const ComparisonView = memo(function ComparisonView({
         onSelectChain={handleAddChain}
         maxChains={4}
       />
-    </motion.div>
+    </div>
   );
 });

--- a/src/components/comparison/index.ts
+++ b/src/components/comparison/index.ts
@@ -1,0 +1,4 @@
+export { ChainSelector } from './ChainSelector';
+export { ComparisonView } from './ComparisonView';
+export { ComparisonMetricsTable } from './ComparisonMetricsTable';
+export { ComparisonChart } from './ComparisonChart';

--- a/src/components/comparison/index.ts
+++ b/src/components/comparison/index.ts
@@ -1,4 +1,4 @@
 export { ChainSelector } from './ChainSelector';
 export { ComparisonView } from './ComparisonView';
 export { ComparisonMetricsTable } from './ComparisonMetricsTable';
-export { ComparisonChart } from './ComparisonChart';
+export { ComparisonChart, type ComparisonMetricType } from './ComparisonChart';

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
-import { getChains, getTPSHistory, getChainValidators } from '../api';
+import { getChains, getTPSHistory, getChainValidators, getL1BeatFeeMetrics } from '../api';
 import { Chain, TPSHistory } from '../types';
 import {
   Activity,
@@ -50,15 +50,20 @@ export function ChainDetails() {
   const [activeTab, setActiveTab] = useState<'validators' | 'compare'>('validators');
   const [hoveredTab, setHoveredTab] = useState<string | null>(null);
   const [availableChains, setAvailableChains] = useState<Chain[]>([]);
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
 
   useEffect(() => {
     async function fetchData() {
       try {
         setLoading(true);
-        const [chains, healthData] = await Promise.all([
+        const [chains, healthData, feeData] = await Promise.all([
           getChains(),
-          getHealth()
+          getHealth(),
+          getL1BeatFeeMetrics()
         ]);
+        const counts: Record<string, number> = {};
+        feeData.forEach((f) => { counts[f.subnet_id] = f.validator_count; });
+        setValidatorCountBySubnet(counts);
 
         const foundChain = chains.find(c => c.chainId === chainId);
 
@@ -643,6 +648,7 @@ export function ChainDetails() {
                 <ComparisonView
                   currentChain={chain}
                   availableChains={availableChains}
+                  validatorCountBySubnet={validatorCountBySubnet}
                 />
               )}
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatValidators, getL1BeatFeeMetrics } from '../api';
+import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatFeeMetrics } from '../api';
 import { Chain, HealthStatus, TeleporterMessageData } from '../types';
 import { ChainCard } from '../components/ChainCard';
 import { ChainListView } from '../components/ChainListView';
@@ -47,13 +47,12 @@ export function Dashboard() {
       const filters: { category?: string } = {};
       if (selectedCategory) filters.category = selectedCategory;
 
-      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, validatorData, feeData] = await Promise.all([
+      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, feeData] = await Promise.all([
         getChains(filters),
         getHealth(),
         getCategories(),
         getAllChainsTPSLatest(),
         getTeleporterMessages(),
-        getL1BeatValidators(undefined, true),
         getL1BeatFeeMetrics()
       ]);
 
@@ -69,18 +68,14 @@ export function Dashboard() {
       }
       setIcmMessageCounts(icmCounts);
 
-      // Build validator count map keyed by subnet_id
+      // Build validator count and fee maps from fee metrics (validator_count is included per subnet)
       const validatorCounts: Record<string, number> = {};
-      validatorData.forEach((v) => {
-        validatorCounts[v.subnet_id] = (validatorCounts[v.subnet_id] || 0) + 1;
-      });
-      setValidatorCountBySubnet(validatorCounts);
-
-      // Build fee metrics map keyed by subnet_id (value in nAVAX)
       const feesMap: Record<string, number> = {};
       feeData.forEach((f) => {
+        validatorCounts[f.subnet_id] = f.validator_count;
         feesMap[f.subnet_id] = f.total_fees_paid;
       });
+      setValidatorCountBySubnet(validatorCounts);
       setFeesBySubnet(feesMap);
 
       // Merge latest TPS from bulk endpoint (backend no longer includes tps on /chains)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages } from '../api';
+import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatValidators, getL1BeatFeeMetrics } from '../api';
 import { Chain, HealthStatus, TeleporterMessageData } from '../types';
 import { ChainCard } from '../components/ChainCard';
 import { ChainListView } from '../components/ChainListView';
@@ -30,6 +30,8 @@ export function Dashboard() {
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [showChainsWithoutValidators, setShowChainsWithoutValidators] = useState(false);
   const [icmMessageCounts, setIcmMessageCounts] = useState<Record<string, number>>({});
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
+  const [feesBySubnet, setFeesBySubnet] = useState<Record<string, number>>({});
 
   async function fetchData() {
     try {
@@ -45,12 +47,14 @@ export function Dashboard() {
       const filters: { category?: string } = {};
       if (selectedCategory) filters.category = selectedCategory;
 
-      const [chainsData, healthData, categoriesData, tpsMap, teleporterData] = await Promise.all([
+      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, validatorData, feeData] = await Promise.all([
         getChains(filters),
         getHealth(),
         getCategories(),
         getAllChainsTPSLatest(),
-        getTeleporterMessages()
+        getTeleporterMessages(),
+        getL1BeatValidators(undefined, true),
+        getL1BeatFeeMetrics()
       ]);
 
       // Calculate ICM message counts per chain
@@ -64,6 +68,20 @@ export function Dashboard() {
         });
       }
       setIcmMessageCounts(icmCounts);
+
+      // Build validator count map keyed by subnet_id
+      const validatorCounts: Record<string, number> = {};
+      validatorData.forEach((v) => {
+        validatorCounts[v.subnet_id] = (validatorCounts[v.subnet_id] || 0) + 1;
+      });
+      setValidatorCountBySubnet(validatorCounts);
+
+      // Build fee metrics map keyed by subnet_id (value in nAVAX)
+      const feesMap: Record<string, number> = {};
+      feeData.forEach((f) => {
+        feesMap[f.subnet_id] = f.total_fees_paid;
+      });
+      setFeesBySubnet(feesMap);
 
       // Merge latest TPS from bulk endpoint (backend no longer includes tps on /chains)
       const chainsWithLatestTps = chainsData.map((chain) => {
@@ -95,11 +113,15 @@ export function Dashboard() {
 
       if (!showChainsWithoutValidators) {
         // Default behavior: only show chains with validators or Avalanche primary chains
-        filteredChains = filteredChains.filter(chain =>
-          (chain.validatorCount && chain.validatorCount >= 1) ||
-          chain.chainName.toLowerCase().includes('avalanche') ||
-          chain.chainName.toLowerCase().includes('c-chain')
-        );
+        filteredChains = filteredChains.filter(chain => {
+          const subnetValidators = chain.subnetId ? validatorCounts[chain.subnetId] : undefined;
+          return (
+            (subnetValidators !== undefined && subnetValidators >= 1) ||
+            (chain.validatorCount && chain.validatorCount >= 1) ||
+            chain.chainName.toLowerCase().includes('avalanche') ||
+            chain.chainName.toLowerCase().includes('c-chain')
+          );
+        });
       }
       // If showChainsWithoutValidators is true, include all chains (no validator filter)
 
@@ -354,9 +376,9 @@ export function Dashboard() {
                 transition={{ duration: 0.3 }}
               >
                 {viewMode === 'table' ? (
-                  <ChainTableView chains={filteredChains} icmMessageCounts={icmMessageCounts} />
+                  <ChainTableView chains={filteredChains} icmMessageCounts={icmMessageCounts} validatorCountBySubnet={validatorCountBySubnet} feesBySubnet={feesBySubnet} />
                 ) : (
-                  <ChainListView chains={filteredChains} />
+                  <ChainListView chains={filteredChains} validatorCountBySubnet={validatorCountBySubnet} />
                 )}
               </motion.div>
             )}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { StatusBar } from '../components/StatusBar';
 import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
+import { ComparisonView } from '../components/comparison';
 import { Footer } from '../components/Footer';
 import { getHealth } from '../api';
 import { HealthStatus } from '../types';
@@ -32,6 +33,11 @@ export function Metrics() {
 
         {/* Chain-Specific Metrics */}
         <ChainSpecificMetrics />
+
+        {/* Chain Comparison */}
+        <section>
+          <ComparisonView />
+        </section>
       </main>
 
       <Footer />

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -4,23 +4,30 @@ import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
 import { ComparisonView } from '../components/comparison';
 import { Footer } from '../components/Footer';
-import { getHealth } from '../api';
+import { getHealth, getL1BeatFeeMetrics } from '../api';
 import { HealthStatus } from '../types';
 
 export function Metrics() {
   const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
 
   useEffect(() => {
-    async function fetchHealth() {
+    async function fetchData() {
       try {
-        const healthData = await getHealth();
+        const [healthData, feeData] = await Promise.all([
+          getHealth(),
+          getL1BeatFeeMetrics()
+        ]);
         setHealth(healthData);
+        const counts: Record<string, number> = {};
+        feeData.forEach((f) => { counts[f.subnet_id] = f.validator_count; });
+        setValidatorCountBySubnet(counts);
       } catch (err) {
-        console.error('Failed to fetch health:', err);
+        console.error('Failed to fetch data:', err);
       }
     }
 
-    fetchHealth();
+    fetchData();
   }, []);
 
   return (
@@ -36,7 +43,7 @@ export function Metrics() {
 
         {/* Chain Comparison */}
         <section>
-          <ComparisonView />
+          <ComparisonView validatorCountBySubnet={validatorCountBySubnet} />
         </section>
       </main>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,3 +416,13 @@ export interface ACPSearchResponse extends ACPListResponse {
   filters: ACPFilters;
   suggestions?: string[];
 }
+
+// ============= CHAIN COMPARISON TYPES =============
+
+export interface ChainComparisonData {
+  chain: Chain;
+  tpsHistory: TPSHistory[];
+  cumulativeTx: CumulativeTxCount[];
+}
+
+export type ComparisonMetricType = 'tps' | 'transactions';

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,22 +198,6 @@ export interface HealthStatus {
 }
 
 // L1Beat external API types (https://api.l1beat.io)
-export interface L1BeatValidatorRecord {
-  subnet_id: string;
-  validation_id: string;
-  node_id: string;
-  balance: number;
-  weight: number;
-  start_time: string;
-  end_time: string;
-  uptime_percentage: number;
-  active: boolean;
-  initial_deposit: number;
-  total_topups: number;
-  refund_amount: number;
-  fees_paid: number;
-}
-
 export interface L1BeatFeeMetrics {
   subnet_id: string;
   total_deposited: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,12 +451,3 @@ export interface ACPSearchResponse extends ACPListResponse {
   suggestions?: string[];
 }
 
-// ============= CHAIN COMPARISON TYPES =============
-
-export interface ChainComparisonData {
-  chain: Chain;
-  tpsHistory: TPSHistory[];
-  cumulativeTx: CumulativeTxCount[];
-}
-
-export type ComparisonMetricType = 'tps' | 'transactions';

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,40 @@ export interface HealthStatus {
   timestamp: number;
 }
 
+// L1Beat external API types (https://api.l1beat.io)
+export interface L1BeatValidatorRecord {
+  subnet_id: string;
+  validation_id: string;
+  node_id: string;
+  balance: number;
+  weight: number;
+  start_time: string;
+  end_time: string;
+  uptime_percentage: number;
+  active: boolean;
+  initial_deposit: number;
+  total_topups: number;
+  refund_amount: number;
+  fees_paid: number;
+}
+
+export interface L1BeatFeeMetrics {
+  subnet_id: string;
+  total_deposited: number;
+  initial_deposits: number;
+  top_up_deposits: number;
+  total_refunded: number;
+  current_balance: number;
+  total_fees_paid: number;
+  deposit_tx_count: number;
+  validator_count: number;
+}
+
+export interface L1BeatApiMeta {
+  limit: number;
+  offset: number;
+}
+
 // Teleporter message types
 export interface TeleporterMessage {
   source: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,11 +226,6 @@ export interface L1BeatFeeMetrics {
   validator_count: number;
 }
 
-export interface L1BeatApiMeta {
-  limit: number;
-  offset: number;
-}
-
 // Teleporter message types
 export interface TeleporterMessage {
   source: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,11 +10,13 @@ export default defineConfig(async ({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), '');
   const apiBaseUrl = env.VITE_API_BASE_URL;
+  const l1beatExternalApi = env.VITE_L1BEAT_EXTERNAL_API;
 
   return {
     define: {
       'process.env': {},
       'import.meta.env.VITE_API_BASE_URL': JSON.stringify(apiBaseUrl),
+      'import.meta.env.VITE_L1BEAT_EXTERNAL_API': JSON.stringify(l1beatExternalApi),
     },
     plugins: [
       react(),


### PR DESCRIPTION
  Integrate validators & fees data from L1Beat API
                                                                                                                                                                                          
  Summary                                                                                                                                                                               
                                         
  - Replaces chain.validatorCount (from the generic /api/chains backend endpoint) with live active validator counts sourced from https://api.l1beat.io/api/v1/metrics/fees — the fee
  metrics response includes validator_count per subnet, so no separate validators endpoint call is needed
  - Replaces the "Coming Soon" placeholder in the Fees to P-Chain column with the actual total_fees_paid value from /api/v1/metrics/fees, converted from nAVAX to AVAX and formatted with
  K/M abbreviations
  - Makes the Fees to P-Chain column sortable
  - Wires validatorCountBySubnet into ComparisonView on both /metrics and /chain/:id — it was always receiving {}