### PR TITLE
Feature/l1beat api integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=your_api_base_url_here
 # http://localhost:5001
+VITE_L1BEAT_EXTERNAL_API=https://api.l1beat.io

--- a/scripts/ssg.js
+++ b/scripts/ssg.js
@@ -86,7 +86,7 @@ async function generate() {
         if (match) return match[1].trim();
       } catch (e) {}
       
-      return 'https://api.l1beat.io'; // Default fallback
+      return process.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io'; // Default fallback
     };
     
     const apiBaseUrl = await getApiUrl();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Dashboard } from './pages/Dashboard';
 import { ChainDetails } from './pages/ChainDetails';
@@ -9,31 +9,43 @@ import { BlogPost } from './pages/BlogPost';
 import { Metrics } from './pages/Metrics';
 import { BrandGuidelines } from './pages/BrandGuidelines';
 import { NotFound } from './pages/NotFound';
+import { StatusBar } from './components/StatusBar';
+import { getHealth } from './api';
+import { HealthStatus } from './types';
 
 function App() {
   const location = useLocation();
   const navigate = useNavigate();
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+
+  useEffect(() => {
+    getHealth().then(setHealth).catch(() => {});
+    const interval = setInterval(() => {
+      getHealth().then(setHealth).catch(() => {});
+    }, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     // Function to extract ACP number from any URL or text
     const extractACPNumber = (url: string, text: string = ''): string | null => {
       const combined = `${url} ${text}`.toLowerCase();
-      
-      // Look for ACP patterns in URLs and text 
+
+      // Look for ACP patterns in URLs and text
       const patterns = [
         /acp[\/\-_]?(\d+)/i,           // acp/123, acp-123, acp_123, acp123
         /\/(\d+)-[^\/]+/,              // /123-something
         /acps\/(\d+)/i,                // acps/123
         /acp-(\d+)/i,                  // ACP-123
       ];
-      
+
       for (const pattern of patterns) {
         const match = combined.match(pattern);
         if (match) {
           return match[1];
         }
       }
-      
+
       return null;
     };
 
@@ -41,7 +53,7 @@ function App() {
     const handleLinkClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       const link = target.closest('a');
-      
+
       if (!link || !link.href) return;
 
       // Only process clicks on ACP pages
@@ -52,8 +64,8 @@ function App() {
       const linkText = link.textContent || '';
 
       // ALWAYS ALLOW: Internal navigation (navbar, back buttons)
-      const isInternalNavigation = 
-        link.closest('nav') || 
+      const isInternalNavigation =
+        link.closest('nav') ||
         link.closest('[role="navigation"]') ||
         link.closest('.navbar') ||
         link.closest('.nav') ||
@@ -93,19 +105,24 @@ function App() {
     };
   }, [location.pathname, navigate]);
 
+  const showTabs = location.pathname !== '/brand';
+
   return (
-    <Routes>
-      <Route path="/" element={<Dashboard />} />
-      <Route path="/chain/:chainId" element={<ChainDetails />} />
-      <Route path="/metrics" element={<Metrics />} />
-      <Route path="/acps" element={<ACPs />} />
-      <Route path="/acps/:acpNumber" element={<ACPDetails />} />
-      <Route path="/blog" element={<BlogList />} />
-      <Route path="/blog/:slug" element={<BlogPost />} />
-      <Route path="/brand" element={<BrandGuidelines />} />
-      <Route path="/404" element={<NotFound />} />
-      <Route path="*" element={<Navigate to="/404" replace />} />
-    </Routes>
+    <>
+      <StatusBar health={health} showTabs={showTabs} />
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/chain/:chainId" element={<ChainDetails />} />
+        <Route path="/metrics" element={<Metrics />} />
+        <Route path="/acps" element={<ACPs />} />
+        <Route path="/acps/:acpNumber" element={<ACPDetails />} />
+        <Route path="/blog" element={<BlogList />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
+        <Route path="/brand" element={<BrandGuidelines />} />
+        <Route path="/404" element={<NotFound />} />
+        <Route path="*" element={<Navigate to="/404" replace />} />
+      </Routes>
+    </>
   );
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1439,39 +1439,105 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
 
 const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
+// Fetch from external APIs without headers that trigger CORS preflight.
+// Only sends Accept: application/json (a CORS-safe header).
+async function fetchExternalWithRetry<T>(
+  url: string,
+  retries: number = 3,
+  backoffFactor: number = 2,
+  timeout: number = 30000
+): Promise<T> {
+  let lastError: Error = new Error('Unknown error occurred');
+  let attempt = 0;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    while (attempt < retries) {
+      try {
+        const response = await fetch(url, {
+          signal: controller.signal,
+          mode: 'cors',
+          credentials: 'omit',
+          headers: { 'Accept': 'application/json' },
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        return await response.json() as T;
+      } catch (error) {
+        lastError = error as Error;
+
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw new Error('Request timeout');
+        }
+
+        attempt++;
+        if (attempt === retries) break;
+
+        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
+    throw lastError;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// Paginate through all pages of an L1Beat external API endpoint.
+async function fetchAllL1BeatPages<T>(
+  endpoint: string,
+  extraParams: Record<string, string> = {}
+): Promise<T[]> {
+  const all: T[] = [];
+  let offset = 0;
+  const limit = 100;
+  let hasMore = true;
+
+  while (hasMore) {
+    const params = new URLSearchParams({ ...extraParams, limit: String(limit), offset: String(offset) });
+    const response = await fetchExternalWithRetry<{ data: T[]; meta: { has_more: boolean } }>(
+      `${L1BEAT_EXTERNAL_API}${endpoint}?${params.toString()}`
+    );
+    const chunk = response.data ?? [];
+    all.push(...chunk);
+    hasMore = response.meta?.has_more ?? false;
+    offset += limit;
+  }
+
+  return all;
+}
+
 export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
   const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
   return fetchWithCache(cacheKey, async () => {
     try {
-      const params = new URLSearchParams();
-      if (subnetId) params.set('subnet_id', subnetId);
-      if (active !== undefined) params.set('active', String(active));
-      params.set('limit', '1000');
-      const response = await fetchWithRetry<{ data: L1BeatValidatorRecord[] }>(
-        `${L1BEAT_EXTERNAL_API}/api/v1/data/validators?${params.toString()}`
-      );
-      return response.data ?? [];
+      const extraParams: Record<string, string> = {};
+      if (subnetId) extraParams['subnet_id'] = subnetId;
+      if (active !== undefined) extraParams['active'] = String(active);
+      return await fetchAllL1BeatPages<L1BeatValidatorRecord>('/api/v1/data/validators', extraParams);
     } catch (error) {
       console.error('L1Beat validators fetch error:', error);
       return [];
     }
-  }, 5 * 60 * 1000); // 5 min cache
+  }, 5 * 60 * 1000);
 }
 
 export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
   const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
   return fetchWithCache(cacheKey, async () => {
     try {
-      const params = new URLSearchParams();
-      if (subnetId) params.set('subnet_id', subnetId);
-      params.set('limit', '1000');
-      const response = await fetchWithRetry<{ data: L1BeatFeeMetrics[] }>(
-        `${L1BEAT_EXTERNAL_API}/api/v1/metrics/fees?${params.toString()}`
-      );
-      return response.data ?? [];
+      const extraParams: Record<string, string> = {};
+      if (subnetId) extraParams['subnet_id'] = subnetId;
+      return await fetchAllL1BeatPages<L1BeatFeeMetrics>('/api/v1/metrics/fees', extraParams);
     } catch (error) {
       console.error('L1Beat fee metrics fetch error:', error);
       return [];
     }
-  }, 5 * 60 * 1000); // 5 min cache
+  }, 5 * 60 * 1000);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1437,7 +1437,7 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
   }, 15 * 60 * 1000); // Cache for 15 minutes
 }
 
-const L1BEAT_EXTERNAL_API = 'https://api.l1beat.io';
+const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
 export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
   const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;

--- a/src/api.ts
+++ b/src/api.ts
@@ -364,7 +364,7 @@ export async function getChains(filters?: { category?: string; network?: 'mainne
           // Native token (used for stake formatting). Default decimals to 18 if missing.
           networkToken: (() => {
             const t = chain.networkToken || chain.token || chain.nativeToken;
-            const symbol = t?.symbol || t?.name || 'TOKEN';
+            const symbol = t?.symbol || t?.name || 'N/A';
             const name = t?.name || symbol;
             const decimals =
               typeof t?.decimals === 'number' && Number.isFinite(t.decimals) ? t.decimals : 18;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatValidatorRecord, L1BeatFeeMetrics } from './types';
+import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatFeeMetrics } from './types';
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
@@ -1439,8 +1439,27 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
 
 const L1BEAT_EXTERNAL_API = import.meta.env.VITE_L1BEAT_EXTERNAL_API || 'https://api.l1beat.io';
 
-// Fetch from external APIs without headers that trigger CORS preflight.
-// Only sends Accept: application/json (a CORS-safe header).
+// Cache wrapper for external API calls — skips the internal rate limiter since
+// these calls go to a different origin and should not consume the backend quota.
+async function fetchExternalWithCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  duration: number = CACHE_DURATION
+): Promise<T> {
+  const cached = cache.get(key);
+  const now = Date.now();
+  if (cached && now - cached.timestamp < duration) {
+    return cached.data;
+  }
+  const data = await fetcher();
+  const sanitizedData = sanitizeResponse(data);
+  cache.set(key, { data: sanitizedData, timestamp: now });
+  return sanitizedData;
+}
+
+// Fetch from external APIs with only CORS-safe headers (no Cache-Control /
+// Content-Type / Origin that trigger a preflight). Creates a fresh
+// AbortController per attempt so retries are not dead after a timeout.
 async function fetchExternalWithRetry<T>(
   url: string,
   retries: number = 3,
@@ -1448,48 +1467,44 @@ async function fetchExternalWithRetry<T>(
   timeout: number = 30000
 ): Promise<T> {
   let lastError: Error = new Error('Unknown error occurred');
-  let attempt = 0;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-  try {
-    while (attempt < retries) {
-      try {
-        const response = await fetch(url, {
-          signal: controller.signal,
-          mode: 'cors',
-          credentials: 'omit',
-          headers: { 'Accept': 'application/json' },
-        });
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        mode: 'cors',
+        credentials: 'omit',
+        headers: { 'Accept': 'application/json' },
+      });
 
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
 
-        return await response.json() as T;
-      } catch (error) {
-        lastError = error as Error;
+      return await response.json() as T;
+    } catch (error) {
+      lastError = error instanceof DOMException && error.name === 'AbortError'
+        ? new Error('Request timeout')
+        : error as Error;
 
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          throw new Error('Request timeout');
-        }
-
-        attempt++;
-        if (attempt === retries) break;
-
-        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
+      if (attempt < retries - 1) {
+        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt + 1), 10000);
         await new Promise(resolve => setTimeout(resolve, delay));
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
-
-    throw lastError;
-  } finally {
-    clearTimeout(timeoutId);
   }
+
+  throw lastError;
 }
 
 // Paginate through all pages of an L1Beat external API endpoint.
+// Stops when has_more is false or a page returns no data (guards against a
+// stuck has_more=true from a misbehaving API).
 async function fetchAllL1BeatPages<T>(
   endpoint: string,
   extraParams: Record<string, string> = {}
@@ -1497,40 +1512,24 @@ async function fetchAllL1BeatPages<T>(
   const all: T[] = [];
   let offset = 0;
   const limit = 100;
-  let hasMore = true;
 
-  while (hasMore) {
+  while (true) {
     const params = new URLSearchParams({ ...extraParams, limit: String(limit), offset: String(offset) });
     const response = await fetchExternalWithRetry<{ data: T[]; meta: { has_more: boolean } }>(
       `${L1BEAT_EXTERNAL_API}${endpoint}?${params.toString()}`
     );
     const chunk = response.data ?? [];
     all.push(...chunk);
-    hasMore = response.meta?.has_more ?? false;
+    if (chunk.length === 0 || !response.meta?.has_more) break;
     offset += limit;
   }
 
   return all;
 }
 
-export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
-  const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
-  return fetchWithCache(cacheKey, async () => {
-    try {
-      const extraParams: Record<string, string> = {};
-      if (subnetId) extraParams['subnet_id'] = subnetId;
-      if (active !== undefined) extraParams['active'] = String(active);
-      return await fetchAllL1BeatPages<L1BeatValidatorRecord>('/api/v1/data/validators', extraParams);
-    } catch (error) {
-      console.error('L1Beat validators fetch error:', error);
-      return [];
-    }
-  }, 5 * 60 * 1000);
-}
-
 export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
   const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
-  return fetchWithCache(cacheKey, async () => {
+  return fetchExternalWithCache(cacheKey, async () => {
     try {
       const extraParams: Record<string, string> = {};
       if (subnetId) extraParams['subnet_id'] = subnetId;

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,15 +3,12 @@ import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
 // XSS protection - sanitize strings in API responses
+// Only encode < and > to prevent HTML tag injection. React already escapes
+// attribute values and text nodes, so encoding & / " / ' here would
+// double-encode and corrupt URLs (e.g. &amp; in image src attributes).
 function sanitizeString(value: string): string {
   if (typeof value !== 'string') return value;
-  
-  // Replace potentially dangerous characters
-  return value
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 // Sanitize API response recursively
@@ -99,7 +96,6 @@ const apiRequestTracker = {
       this.rateLimitTimeout = setTimeout(() => {
         this.isRateLimited = false;
         this.requests = [];
-        console.log('Rate limit reset');
       }, REQUEST_PERIOD);
     }
     
@@ -132,7 +128,6 @@ async function fetchWithCache<T>(
     
     // If we have cached data (even if expired), use it
     if (cached) {
-      console.log(`Using stale cached data for ${key} due to rate limiting`);
       return cached.data;
     }
   }
@@ -161,81 +156,79 @@ async function fetchWithRetry<T>(
 ): Promise<T> {
   let lastError: Error = new Error('Unknown error occurred');
   let attempt = 0;
-  
-  // Create a new AbortController for each retry attempt
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
-  
-  try {
-    while (attempt < retries) {
-      try {
-        const response = await fetch(url, {
-          ...options,
-          signal: controller.signal,
-          mode: 'cors',
-          credentials: 'omit',
-          headers: {
-            ...DEFAULT_HEADERS,
-            ...options.headers,
-            'Cache-Control': 'no-cache',
-          },
-        });
 
-        // Check for HTTP errors
-        if (!response.ok) {
-          if (response.status === 504) {
-            throw new Error('Server timeout - The request took too long to complete');
-          }
-          if (response.status === 429) {
-            throw new Error('Rate limit exceeded - Please try again later');
-          }
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
+  while (attempt < retries) {
+    // Fresh controller per attempt so a timeout on one attempt doesn't
+    // permanently abort the signal shared by subsequent retries.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('application/json')) {
-          const data = await response.json();
-          return data;
-        }
+    try {
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+        mode: 'cors',
+        credentials: 'omit',
+        headers: {
+          ...DEFAULT_HEADERS,
+          ...options.headers,
+          'Cache-Control': 'no-cache',
+        },
+      });
 
-        throw new Error('Invalid content type');
-      } catch (error) {
-        lastError = error as Error;
-        
-        // Check if the request was aborted (timeout)
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          throw new Error('Request timeout - The connection to the server timed out');
+      clearTimeout(timeoutId);
+
+      // Check for HTTP errors
+      if (!response.ok) {
+        if (response.status === 504) {
+          throw new Error('Server timeout - The request took too long to complete');
         }
-        
-        // Check if it's a CORS error
-        if (error instanceof TypeError && error.message.includes('CORS')) {
-          console.error('CORS error detected:', error);
-          break; // Exit retry loop and return fallback data
+        if (response.status === 429) {
+          throw new Error('Rate limit exceeded - Please try again later');
         }
-        
-        // Check for network errors (offline)
-        if (error instanceof TypeError && (error.message.includes('Failed to fetch') || error.message.includes('Network request failed'))) {
-          console.error('Network error detected:', error);
-          break; // Exit retry loop and return fallback data
-        }
-        
-        attempt++;
-        
-        if (attempt === retries) break;
-        
-        const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
-        const jitter = Math.random() * 1000;
-        await new Promise(resolve => setTimeout(resolve, delay + jitter));
+        throw new Error(`HTTP error! status: ${response.status}`);
       }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        const data = await response.json();
+        return data;
+      }
+
+      throw new Error('Invalid content type');
+    } catch (error) {
+      clearTimeout(timeoutId);
+      lastError = error as Error;
+
+      // Check if the request was aborted (timeout)
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw new Error('Request timeout - The connection to the server timed out');
+      }
+
+      // Check if it's a CORS error
+      if (error instanceof TypeError && error.message.includes('CORS')) {
+        console.error('CORS error detected:', error);
+        break; // Exit retry loop and return fallback data
+      }
+
+      // Check for network errors (offline)
+      if (error instanceof TypeError && (error.message.includes('Failed to fetch') || error.message.includes('Network request failed'))) {
+        console.error('Network error detected:', error);
+        break; // Exit retry loop and return fallback data
+      }
+
+      attempt++;
+
+      if (attempt === retries) break;
+
+      const delay = Math.min(1000 * Math.pow(backoffFactor, attempt), 10000);
+      const jitter = Math.random() * 1000;
+      await new Promise(resolve => setTimeout(resolve, delay + jitter));
     }
-    
-    // If we've exhausted all retries, return fallback data instead of throwing
-    console.warn('All retry attempts failed, returning fallback data:', lastError.message);
-    return getFallbackData<T>();
-  } finally {
-    // Always clear the timeout to prevent memory leaks
-    clearTimeout(timeoutId);
   }
+
+  console.warn('All retry attempts failed, returning fallback data:', lastError.message);
+  return getFallbackData<T>();
 }
 
 // Fallback data generator
@@ -291,28 +284,31 @@ export async function getChains(filters?: { category?: string; network?: 'mainne
       const url = `${API_URL}/chains${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
       const data = await fetchWithRetry<any[]>(url);
 
-      const chains = data.map((chain) => {
-        // Debug: Log chain data to see networkToken field
-        if (!chain.networkToken && !chain.token && !chain.nativeToken) {
-          console.log(`Chain ${chain.chainName} missing networkToken field. Available fields:`, Object.keys(chain));
-        }
+      // Track seen slugs to prevent routing collisions between chains whose
+      // names reduce to the same slug after lowercasing and stripping specials.
+      const seenSlugs = new Map<string, number>();
 
+      const chains = data.map((chain) => {
         // Handle potential backend property name changes
         // Prioritize using the chain name as the primary ID for URLs, but keep numeric IDs for other purposes if needed
         // We sanitize the chain name to be URL-friendly (lowercase, replace spaces with dashes)
         const rawChainId = chain.evmChainId || chain.chainId || chain.id || chain._id;
-        
+
         // Generate a slug from the chain name if available
-        let chainSlug = rawChainId;
+        let baseSlug = String(rawChainId || '');
         if (chain.chainName) {
-          chainSlug = chain.chainName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+          baseSlug = chain.chainName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
         }
-        
-        if (!chainSlug) {
+
+        if (!baseSlug) {
           console.warn('Chain missing ID and Name:', chain);
-          // Fallback to a random string if absolutely nothing is available (should shouldn't happen)
-           chainSlug = Math.random().toString(36).substring(7);
+          baseSlug = Math.random().toString(36).substring(7);
         }
+
+        // Deduplicate: append -2, -3, … for any slug seen more than once
+        const count = seenSlugs.get(baseSlug) ?? 0;
+        seenSlugs.set(baseSlug, count + 1);
+        const chainSlug = count === 0 ? baseSlug : `${baseSlug}-${count + 1}`;
 
         const validatorCountRaw = chain.validatorCount || chain.validatorsCount || chain.validator_count || chain.nodeCount || 0;
         const validatorCount = Number(validatorCountRaw);
@@ -1315,7 +1311,6 @@ export async function getNetworkActiveAddressesHistory(days: number = 30): Promi
 export async function getDailyActiveAddresses(chainId: string, days: number = 30): Promise<DailyActiveAddresses[]> {
   return fetchWithCache(`daily-active-addresses-${chainId}-${days}`, async () => {
     try {
-      console.log(`Fetching daily active addresses for chainId: ${chainId}, days: ${days}`);
       const timestamp = Math.floor(Date.now() / 1000);
       const url = `${API_URL}/chains/${chainId}/active-addresses/history?days=${days}&t=${timestamp}`;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator } from './types';
+import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus, TeleporterMessageData, TeleporterDailyData, CumulativeTxCount, CumulativeTxCountResponse, DailyTxCount, DailyTxCountLatest, MaxTPSHistory, MaxTPSLatest, GasUsedHistory, GasUsedLatest, AvgGasPriceHistory, AvgGasPriceLatest, FeesPaidHistory, FeesPaidLatest, NetworkValidatorTotal, Validator, L1BeatValidatorRecord, L1BeatFeeMetrics } from './types';
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
@@ -1424,15 +1424,54 @@ export async function getTeleporterDailyHistory(days: number = 30): Promise<Tele
       const response = await fetchWithRetry<{ data: TeleporterDailyData[] }>(
         `${API_URL}/teleporter/messages/historical-daily?days=${days}`
       );
-      
+
       if (!response.data || !Array.isArray(response.data)) {
         throw new Error('Invalid Teleporter daily history data format');
       }
-      
+
       return response.data;
     } catch (error) {
       console.error('Teleporter daily history fetch error:', error);
       return [];
     }
   }, 15 * 60 * 1000); // Cache for 15 minutes
+}
+
+const L1BEAT_EXTERNAL_API = 'https://api.l1beat.io';
+
+export async function getL1BeatValidators(subnetId?: string, active?: boolean): Promise<L1BeatValidatorRecord[]> {
+  const cacheKey = `l1beat-validators-${subnetId ?? 'all'}-${active ?? 'all'}`;
+  return fetchWithCache(cacheKey, async () => {
+    try {
+      const params = new URLSearchParams();
+      if (subnetId) params.set('subnet_id', subnetId);
+      if (active !== undefined) params.set('active', String(active));
+      params.set('limit', '1000');
+      const response = await fetchWithRetry<{ data: L1BeatValidatorRecord[] }>(
+        `${L1BEAT_EXTERNAL_API}/api/v1/data/validators?${params.toString()}`
+      );
+      return response.data ?? [];
+    } catch (error) {
+      console.error('L1Beat validators fetch error:', error);
+      return [];
+    }
+  }, 5 * 60 * 1000); // 5 min cache
+}
+
+export async function getL1BeatFeeMetrics(subnetId?: string): Promise<L1BeatFeeMetrics[]> {
+  const cacheKey = `l1beat-fees-${subnetId ?? 'all'}`;
+  return fetchWithCache(cacheKey, async () => {
+    try {
+      const params = new URLSearchParams();
+      if (subnetId) params.set('subnet_id', subnetId);
+      params.set('limit', '1000');
+      const response = await fetchWithRetry<{ data: L1BeatFeeMetrics[] }>(
+        `${L1BEAT_EXTERNAL_API}/api/v1/metrics/fees?${params.toString()}`
+      );
+      return response.data ?? [];
+    } catch (error) {
+      console.error('L1Beat fee metrics fetch error:', error);
+      return [];
+    }
+  }, 5 * 60 * 1000); // 5 min cache
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,7 +69,7 @@ const DEFAULT_HEADERS = {
 };
 
 // Define constants for rate limiting
-const REQUEST_LIMIT = 50; // Max requests per minute
+const REQUEST_LIMIT = 200; // Max requests per minute
 const REQUEST_PERIOD = 60 * 1000; // 1 minute in milliseconds
 
 // Track API calls for rate limiting

--- a/src/components/ChainListView.tsx
+++ b/src/components/ChainListView.tsx
@@ -6,12 +6,14 @@ import { motion } from 'framer-motion';
 
 interface ChainListViewProps {
   chains: Chain[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 interface ChainListItemProps {
   chain: Chain;
   index: number;
   onNavigate: (chainId: string) => void;
+  validatorCount: number;
 }
 
 // Helper functions moved outside component
@@ -31,7 +33,7 @@ const getTPSColor = (tpsStr: string) => {
 };
 
 // Memoized list item to prevent re-renders during parent animations
-const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: ChainListItemProps) {
+const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate, validatorCount }: ChainListItemProps) {
   const tpsValue = formatTPS(chain.tps);
   const tpsColor = getTPSColor(tpsValue);
   
@@ -90,7 +92,7 @@ const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: 
             <div className="flex items-center gap-1 min-w-[30px]">
               <Server className="w-3 h-3 text-muted-foreground flex-shrink-0" />
               <span className="text-xs font-medium text-muted-foreground">
-                {chain.validatorCount || 0}
+                {validatorCount}
               </span>
             </div>
             <div className="w-px h-3 bg-border flex-shrink-0"></div>
@@ -110,13 +112,13 @@ const ChainListItem = memo(function ChainListItem({ chain, index, onNavigate }: 
   return (
     prevProps.chain.chainId === nextProps.chain.chainId &&
     prevProps.chain.tps?.value === nextProps.chain.tps?.value &&
-    prevProps.chain.validatorCount === nextProps.chain.validatorCount &&
+    prevProps.validatorCount === nextProps.validatorCount &&
     prevProps.index === nextProps.index
   );
 });
 
 // Memoized container component
-export const ChainListView = memo(function ChainListView({ chains }: ChainListViewProps) {
+export const ChainListView = memo(function ChainListView({ chains, validatorCountBySubnet = {} }: ChainListViewProps) {
   const navigate = useNavigate();
 
   const handleNavigate = useCallback((chainId: string) => {
@@ -127,14 +129,18 @@ export const ChainListView = memo(function ChainListView({ chains }: ChainListVi
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
-      {chains.map((chain, index) => (
-        <ChainListItem
-          key={chain.chainId}
-          chain={chain}
-          index={index}
-          onNavigate={handleNavigate}
-        />
-      ))}
+      {chains.map((chain, index) => {
+        const validatorCount = (chain.subnetId ? validatorCountBySubnet[chain.subnetId] : undefined) ?? chain.validatorCount ?? 0;
+        return (
+          <ChainListItem
+            key={chain.chainId}
+            chain={chain}
+            index={index}
+            onNavigate={handleNavigate}
+            validatorCount={validatorCount}
+          />
+        );
+      })}
     </div>
   );
 });

--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -16,6 +16,8 @@ import {
 interface ChainTableViewProps {
   chains: Chain[];
   icmMessageCounts?: Record<string, number>;
+  validatorCountBySubnet?: Record<string, number>;
+  feesBySubnet?: Record<string, number>;
 }
 
 type SortField =
@@ -66,6 +68,15 @@ const formatTimestamp = (timestamp: number | undefined) => {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+};
+
+const formatFeesAvax = (nAvax: number | undefined): string => {
+  if (nAvax === undefined || nAvax === null) return "N/A";
+  const avax = nAvax / 1_000_000_000;
+  if (avax === 0) return "0 AVAX";
+  if (avax >= 1_000_000) return `${(avax / 1_000_000).toFixed(2)}M AVAX`;
+  if (avax >= 1_000) return `${(avax / 1_000).toFixed(2)}K AVAX`;
+  return `${avax.toFixed(2)} AVAX`;
 };
 
 // Placeholder badge components for missing data
@@ -127,6 +138,8 @@ const SortHeader = ({
 export const ChainTableView = memo(function ChainTableView({
   chains,
   icmMessageCounts = {},
+  validatorCountBySubnet = {},
+  feesBySubnet = {},
 }: ChainTableViewProps) {
   const navigate = useNavigate();
   const [sortConfig, setSortConfig] = useState<SortConfig>({
@@ -176,8 +189,8 @@ export const ChainTableView = memo(function ChainTableView({
         return order * (tpsA - tpsB);
 
       case "validators":
-        const validatorsA = a.validatorCount ?? 0;
-        const validatorsB = b.validatorCount ?? 0;
+        const validatorsA = (a.subnetId ? validatorCountBySubnet[a.subnetId] : undefined) ?? a.validatorCount ?? 0;
+        const validatorsB = (b.subnetId ? validatorCountBySubnet[b.subnetId] : undefined) ?? b.validatorCount ?? 0;
         return order * (validatorsA - validatorsB);
 
       case "nativeToken":
@@ -190,9 +203,14 @@ export const ChainTableView = memo(function ChainTableView({
         const icmB = icmMessageCounts[b.chainName] || 0;
         return order * (icmA - icmB);
 
+      case "feesToPChain": {
+        const feesA = a.subnetId ? (feesBySubnet[a.subnetId] ?? -1) : -1;
+        const feesB = b.subnetId ? (feesBySubnet[b.subnetId] ?? -1) : -1;
+        return order * (feesA - feesB);
+      }
+
       // Placeholder sorts for missing data
       case "networkStatus":
-      case "feesToPChain":
       case "governanceStage":
       case "riskLevel":
         return 0;
@@ -281,6 +299,9 @@ export const ChainTableView = memo(function ChainTableView({
             {sortedChains.map((chain, index) => {
               const tpsValue = formatTPS(chain.tps);
               const tpsColor = getTPSColor(tpsValue);
+              const validatorCount = (chain.subnetId ? validatorCountBySubnet[chain.subnetId] : undefined) ?? chain.validatorCount ?? 0;
+              const feesNAvax = chain.subnetId ? feesBySubnet[chain.subnetId] : undefined;
+              const feesDisplay = formatFeesAvax(feesNAvax);
 
               return (
                 <motion.tr
@@ -348,7 +369,7 @@ export const ChainTableView = memo(function ChainTableView({
                     <div className="flex items-center gap-1.5">
                       <Server className="w-3.5 h-3.5 text-muted-foreground" />
                       <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {chain.validatorCount || 0}
+                        {validatorCount}
                       </span>
                     </div>
                   </td>
@@ -394,9 +415,15 @@ export const ChainTableView = memo(function ChainTableView({
                     })()}
                   </td>
 
-                  {/* Fees to P-Chain (Monthly) - Coming Soon */}
+                  {/* Fees to P-Chain */}
                   <td className="px-3 py-3">
-                    <ComingSoonBadge />
+                    {feesNAvax !== undefined ? (
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {feesDisplay}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">N/A</span>
+                    )}
                   </td>
 
                   {/* Governance Stage - Coming Soon */}

--- a/src/components/ChainTableView.tsx
+++ b/src/components/ChainTableView.tsx
@@ -272,7 +272,7 @@ export const ChainTableView = memo(function ChainTableView({
               />
               <SortHeader
                 field="feesToPChain"
-                label="Fees to P-Chain (Monthly)"
+                label="Fees to P-Chain (Total)"
                 sortConfig={sortConfig}
                 onSort={handleSort}
               />

--- a/src/components/StakeDistributionChart.tsx
+++ b/src/components/StakeDistributionChart.tsx
@@ -32,7 +32,7 @@ export function StakeDistributionChart({ validators, mode, tokenSymbol, tokenDec
     mode === 'weight' ? true : mode === 'tokens' ? false : validators.some(v => v.stakeUnit === 'weight');
 
   const decimals = typeof tokenDecimals === 'number' && Number.isFinite(tokenDecimals) ? tokenDecimals : 18;
-  const unitLabel = isWeightMode ? 'weight' : (tokenSymbol || 'TOKEN');
+  const unitLabel = isWeightMode ? 'weight' : (tokenSymbol || 'N/A');
 
   const { data, totalStakeBaseUnits, baseByIndex } = useMemo(() => {
     const getStakeBase = (v: Validator) => parseBaseUnits(v.weight) ?? 0n;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,6 @@
-import { AlertTriangle, Menu, X, ExternalLink, LayoutGrid, FileText, BookOpen, BarChart3, Code } from 'lucide-react';
+import { AlertTriangle, Menu, X, LayoutGrid, FileText, BookOpen, BarChart3, Code } from 'lucide-react';
 import { HealthStatus } from '../types';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ThemeToggle } from './ThemeToggle';
 import { useTheme } from '../hooks/useTheme';
@@ -12,13 +12,9 @@ interface StatusBarProps {
 }
 
 export function StatusBar({ health, showTabs = true }: StatusBarProps) {
-  const [isVisible, setIsVisible] = useState(true);
-  const [lastScrollY, setLastScrollY] = useState(0);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
-  const [showComingSoon, setShowComingSoon] = useState(false);
-  
-  // Navigation tabs configuration
+
   const navTabs = [
     { id: 'dashboard', label: 'Dashboard', path: '/', icon: LayoutGrid },
     { id: 'metrics', label: 'Metrics', path: '/metrics', icon: BarChart3 },
@@ -26,24 +22,10 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
     { id: 'blog', label: 'Blog', path: '/blog', icon: BookOpen },
     { id: 'api', label: 'API', path: '', icon: Code, comingSoon: true },
   ];
+
   const location = useLocation();
   const navigate = useNavigate();
   const { theme } = useTheme();
-
-  useEffect(() => {
-    const controlNavbar = () => {
-      const currentScrollY = window.scrollY;
-      if (currentScrollY < lastScrollY || currentScrollY < 50) {
-        setIsVisible(true);
-      } else if (currentScrollY > lastScrollY && currentScrollY > 50) {
-        setIsVisible(false);
-      }
-      setLastScrollY(currentScrollY);
-    };
-
-    window.addEventListener('scroll', controlNavbar);
-    return () => window.removeEventListener('scroll', controlNavbar);
-  }, [lastScrollY]);
 
   const handleLogoClick = () => {
     if (!isAnimating) {
@@ -61,15 +43,13 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
   };
 
   return (
-    <>
-      <div className={`sticky top-0 z-50 transform transition-transform duration-300 ${isVisible ? 'translate-y-0' : '-translate-y-full'
-        }`}>
-        {/* Alpha Warning Banner */}
+    <div className="sticky top-0 z-50">
+      {/* Alpha Warning Banner */}
       <div className="bg-[#ef4444]/15 supports-[backdrop-filter]:bg-[#ef4444]/10 supports-[backdrop-filter]:backdrop-blur-md border-b border-[#ef4444]/20 px-4 sm:px-6 py-2 flex items-center justify-center gap-2">
         <AlertTriangle className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-[#ef4444] flex-shrink-0" />
         <p className="text-xs sm:text-sm font-medium text-[#ef4444] text-center">
-              L1Beat is currently in alpha. Data shown may be incomplete or inaccurate.
-            </p>
+          L1Beat is currently in alpha. Data shown may be incomplete or inaccurate.
+        </p>
       </div>
 
       {/* Main Navigation */}
@@ -83,12 +63,9 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
                 className="relative transform transition-all duration-300 hover:scale-105 focus:outline-none group"
               >
                 <div
-                  className={`absolute inset-0 bg-[#ef4444]/20 dark:bg-[#ef4444]/30 rounded-lg filter blur-xl transition-opacity duration-500 ${isAnimating ?
-                    'animate-heartbeat-glow' : 'opacity-0'
-                    }`}
+                  className={`absolute inset-0 bg-[#ef4444]/20 dark:bg-[#ef4444]/30 rounded-lg filter blur-xl transition-opacity duration-500 ${isAnimating ? 'animate-heartbeat-glow' : 'opacity-0'}`}
                 />
-                <div className={`relative ${isAnimating ? 'animate-heartbeat' : ''
-                    } transition-transform duration-300`}>
+                <div className={`relative ${isAnimating ? 'animate-heartbeat' : ''} transition-transform duration-300`}>
                   <L1BeatLogo size="small" theme={theme} variant="header" />
                 </div>
               </button>
@@ -124,8 +101,7 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
           </div>
 
           {/* Mobile Menu */}
-          <div className={`md:hidden transition-all duration-300 ease-in-out ${isMobileMenuOpen ? 'max-h-64 opacity-100' : 'max-h-0 opacity-0 overflow-hidden'
-            }`}>
+          <div className={`md:hidden transition-all duration-300 ease-in-out ${isMobileMenuOpen ? 'max-h-64 opacity-100' : 'max-h-0 opacity-0 overflow-hidden'}`}>
             <div className="px-2 pt-2 pb-3 space-y-1 border-t border-border">
               <div className="pt-4 border-t border-border">
                 <div className="flex items-center justify-between px-3">
@@ -146,10 +122,7 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
               {navTabs.map(({ id, label, path, icon: Icon, comingSoon }) => {
                 if (comingSoon) {
                   return (
-                    <div 
-                      key={id} 
-                      className="relative group"
-                    >
+                    <div key={id} className="relative group">
                       <button
                         className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 border-transparent text-muted-foreground transition-colors whitespace-nowrap cursor-not-allowed opacity-75"
                         disabled
@@ -168,28 +141,23 @@ export function StatusBar({ health, showTabs = true }: StatusBarProps) {
                 const active = isActive(path);
                 const tabClassName = `
                   flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 transition-colors whitespace-nowrap
-                  ${active 
-                    ? 'border-[#ef4444] text-foreground' 
+                  ${active
+                    ? 'border-[#ef4444] text-foreground'
                     : 'border-transparent text-muted-foreground hover:text-foreground'
                   }
                 `;
 
                 return (
-                  <Link 
-                    key={id} 
-                    to={path}
-                    className={tabClassName}
-                  >
+                  <Link key={id} to={path} className={tabClassName}>
                     <Icon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                     <span className="text-xs sm:text-sm">{label}</span>
                   </Link>
                 );
               })}
-        </div>
-      </div>
+            </div>
+          </div>
         </nav>
       )}
-      </div>
-    </>
+    </div>
   );
 }

--- a/src/components/comparison/ChainSelector.tsx
+++ b/src/components/comparison/ChainSelector.tsx
@@ -39,11 +39,9 @@ export const ChainSelector = memo(function ChainSelector({
     setSearchTerm('');
   };
 
-  if (!isOpen) return null;
-
   return createPortal(
     <AnimatePresence>
-      <motion.div
+      {isOpen && <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -173,7 +171,7 @@ export const ChainSelector = memo(function ChainSelector({
             )}
           </div>
         </motion.div>
-      </motion.div>
+      </motion.div>}
     </AnimatePresence>,
     document.body
   );

--- a/src/components/comparison/ComparisonMetricsTable.tsx
+++ b/src/components/comparison/ComparisonMetricsTable.tsx
@@ -16,17 +16,19 @@ interface ChainComparisonData {
 
 interface ComparisonMetricsTableProps {
   comparisonChains: ChainComparisonData[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 export const ComparisonMetricsTable = memo(function ComparisonMetricsTable({
-  comparisonChains
+  comparisonChains,
+  validatorCountBySubnet = {}
 }: ComparisonMetricsTableProps) {
   const metrics = useMemo(() => {
     const chains = comparisonChains.map(data => {
       const latestMaxTps = data.maxTPS.length > 0
         ? data.maxTPS[data.maxTPS.length - 1].value
         : 0;
-      const validatorCount = data.chain.validatorCount || 0;
+      const validatorCount = (data.chain.subnetId ? validatorCountBySubnet[data.chain.subnetId] : undefined) ?? data.chain.validatorCount ?? 0;
       const latestDailyTx = data.dailyTxCount.length > 0
         ? data.dailyTxCount[data.dailyTxCount.length - 1].value
         : 0;

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -59,7 +59,9 @@ export const ComparisonView = memo(function ComparisonView({
   const timeframeParam = searchParams.get('timeframe');
   const timeframe = (timeframeParam === '30' ? 30 : 7) as 7 | 30;
 
-  // Update URL with current state
+  // Update URL with current state. Always writes both timeframe and metric so
+  // that partial updates (e.g. changing only the metric) don't silently drop
+  // the other param and break shareable URLs.
   const updateUrl = useCallback((chainIds: string[], newTimeframe?: number, newMetric?: ComparisonMetricType) => {
     const newParams = new URLSearchParams(searchParams);
 
@@ -69,16 +71,11 @@ export const ComparisonView = memo(function ComparisonView({
       newParams.delete('compare');
     }
 
-    if (newTimeframe) {
-      newParams.set('timeframe', String(newTimeframe));
-    }
-
-    if (newMetric) {
-      newParams.set('metric', newMetric);
-    }
+    newParams.set('timeframe', String(newTimeframe ?? timeframe));
+    newParams.set('metric', newMetric ?? selectedMetric);
 
     setSearchParams(newParams, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, timeframe, selectedMetric]);
 
   // Handle timeframe change
   const handleTimeframeChange = useCallback((newTimeframe: 7 | 30) => {
@@ -143,24 +140,29 @@ export const ComparisonView = memo(function ComparisonView({
     fetchAvailableChains();
   }, [providedChains]);
 
-  // Fetch all 6 metric types for a chain
-  const fetchChainData = useCallback(async (chain: Chain, index: number) => {
+  // Fetch all 6 metric types for a chain. Keyed by chainId (not positional
+  // index) so that concurrent adds don't overwrite each other's slots when
+  // React state hasn't committed yet.
+  const fetchChainData = useCallback(async (chain: Chain) => {
+    const targetChainId = chain.chainId;
     try {
-      const chainId = chain.originalChainId || chain.chainId;
-      const evmChainIdStr = chain.evmChainId ? String(chain.evmChainId) : chainId;
+      const apiChainId = chain.originalChainId || chain.chainId;
+      const evmChainIdStr = chain.evmChainId ? String(chain.evmChainId) : apiChainId;
 
       const [activeAddresses, dailyTx, maxTps, gasUsedData, avgGasPriceData, feesPaidData] = await Promise.all([
         getDailyActiveAddresses(evmChainIdStr, timeframe).catch(() => []),
-        getChainTxCountHistory(chainId, timeframe).catch(() => []),
-        getChainMaxTPSHistory(chainId, timeframe).catch(() => []),
-        getChainGasUsedHistory(chainId, timeframe).catch(() => []),
-        getChainAvgGasPriceHistory(chainId, timeframe).catch(() => []),
-        getChainFeesPaidHistory(chainId, timeframe).catch(() => [])
+        getChainTxCountHistory(apiChainId, timeframe).catch(() => []),
+        getChainMaxTPSHistory(apiChainId, timeframe).catch(() => []),
+        getChainGasUsedHistory(apiChainId, timeframe).catch(() => []),
+        getChainAvgGasPriceHistory(apiChainId, timeframe).catch(() => []),
+        getChainFeesPaidHistory(apiChainId, timeframe).catch(() => [])
       ]);
 
       setComparisonChains(prev => {
+        const idx = prev.findIndex(c => c.chain.chainId === targetChainId);
+        if (idx === -1) return prev; // chain was removed while loading
         const updated = [...prev];
-        updated[index] = {
+        updated[idx] = {
           chain,
           dailyActiveAddresses: activeAddresses,
           dailyTxCount: dailyTx,
@@ -175,11 +177,10 @@ export const ComparisonView = memo(function ComparisonView({
     } catch (error) {
       console.error('Failed to fetch chain data:', error);
       setComparisonChains(prev => {
+        const idx = prev.findIndex(c => c.chain.chainId === targetChainId);
+        if (idx === -1) return prev;
         const updated = [...prev];
-        updated[index] = {
-          ...updated[index],
-          loading: false
-        };
+        updated[idx] = { ...updated[idx], loading: false };
         return updated;
       });
     }
@@ -212,8 +213,8 @@ export const ComparisonView = memo(function ComparisonView({
 
       if (initialChains.length > 0) {
         setComparisonChains(initialChains);
-        initialChains.forEach((data, index) => {
-          fetchChainData(data.chain, index);
+        initialChains.forEach((data) => {
+          fetchChainData(data.chain);
         });
       }
     } else if (currentChain) {
@@ -227,7 +228,7 @@ export const ComparisonView = memo(function ComparisonView({
         feesPaid: [],
         loading: true
       }]);
-      fetchChainData(currentChain, 0);
+      fetchChainData(currentChain);
       updateUrl([currentChain.chainId]);
     }
 
@@ -247,8 +248,8 @@ export const ComparisonView = memo(function ComparisonView({
 
       const updated = prev.map(c => ({ ...c, loading: true }));
 
-      prev.forEach((data, index) => {
-        fetchChainData(data.chain, index);
+      prev.forEach((data) => {
+        fetchChainData(data.chain);
       });
 
       return updated;
@@ -259,7 +260,6 @@ export const ComparisonView = memo(function ComparisonView({
     if (comparisonChains.length >= 4) return;
     if (comparisonChains.some(c => c.chain.chainId === chain.chainId)) return;
 
-    const newIndex = comparisonChains.length;
     const newChains = [
       ...comparisonChains,
       {
@@ -277,7 +277,7 @@ export const ComparisonView = memo(function ComparisonView({
 
     updateUrl(newChains.map(c => c.chain.chainId));
 
-    fetchChainData(chain, newIndex);
+    fetchChainData(chain);
     setIsModalOpen(false);
   };
 

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -12,6 +12,7 @@ import { LoadingSpinner } from '../LoadingSpinner';
 interface ComparisonViewProps {
   currentChain?: Chain;
   availableChains?: Chain[];
+  validatorCountBySubnet?: Record<string, number>;
 }
 
 interface ChainComparisonData {
@@ -36,7 +37,8 @@ const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; valueLabel: 
 
 export const ComparisonView = memo(function ComparisonView({
   currentChain,
-  availableChains: providedChains
+  availableChains: providedChains,
+  validatorCountBySubnet = {}
 }: ComparisonViewProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -451,7 +453,7 @@ export const ComparisonView = memo(function ComparisonView({
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.4, delay: 0.1 }}
             >
-              <ComparisonMetricsTable comparisonChains={comparisonChains} />
+              <ComparisonMetricsTable comparisonChains={comparisonChains} validatorCountBySubnet={validatorCountBySubnet} />
             </motion.div>
 
             {/* Controls: Metric Dropdown, Timeframe, Share */}

--- a/src/pages/ACPDetails.tsx
+++ b/src/pages/ACPDetails.tsx
@@ -8,7 +8,6 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { useTheme } from '../hooks/useTheme';
 import 'katex/dist/katex.min.css';
-import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import {
@@ -28,8 +27,6 @@ import {
   BookOpen,
   Info
 } from 'lucide-react';
-import { getHealth } from '../api';
-import { HealthStatus } from '../types';
 import { acpService, LocalACP } from '../services/acpService';
 const preprocessContent = (content: string) => {
   return content
@@ -59,7 +56,6 @@ export default function ACPDetails() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [health, setHealth] = useState<HealthStatus | null>(null);
 
   // Dynamically load syntax highlighter only on client side
   const [SyntaxHighlighter, setSyntaxHighlighter] = useState<any>(null);
@@ -92,20 +88,16 @@ export default function ACPDetails() {
         setError(null);
 
         console.log(`Loading ACP-${acpNumber} from local data...`);
-        const [acpData, healthData] = await Promise.all([
-          acpService.loadACPByNumber(acpNumber),
-          getHealth(),
-        ]);
-        
+        const acpData = await acpService.loadACPByNumber(acpNumber);
+
         if (!mounted) return;
-        
+
         if (!acpData) {
           setError(`ACP-${acpNumber} not found`);
           return;
         }
 
         setAcp(acpData);
-        setHealth(healthData);
       } catch (err) {
         if (!mounted) return;
         console.error(`Error loading ACP-${acpNumber}:`, err);
@@ -451,7 +443,6 @@ export default function ACPDetails() {
   if (loading) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <LoadingSpinner size="lg" />
@@ -470,7 +461,6 @@ export default function ACPDetails() {
   if (error || !acp) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center max-w-md">
             <AlertTriangle className="w-8 h-8 mx-auto mb-4 text-red-600" />
@@ -510,8 +500,6 @@ export default function ACPDetails() {
 
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
-      <StatusBar health={health} />
-
       <div className="flex-1">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}

--- a/src/pages/ACPs.tsx
+++ b/src/pages/ACPs.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
-import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import {
@@ -27,10 +26,8 @@ import {
   Code,
   AlertCircle
 } from 'lucide-react';
-import { getHealth } from '../api';
 import { acpService, LocalACP, EnhancedACP, ACPStats } from '../services/acpService';
 import EnhancedACPCard from '../components/ACPCard';
-import type { HealthStatus } from '../types';
 
 
 type ViewMode = 'grid' | 'list';
@@ -67,8 +64,6 @@ export default function ACPs() {
 
   });
 
-  const [health, setHealth] = useState<HealthStatus | null>(null);
-
   useEffect(() => {
     let mounted = true;
     
@@ -80,19 +75,15 @@ export default function ACPs() {
         setError(null);
 
         console.log('Loading ACPs from local data...');
-        const [acpsData, healthData] = await Promise.all([
-          acpService.loadACPs(),
-          getHealth(),
-        ]);
-        
+        const acpsData = await acpService.loadACPs();
+
         if (!mounted) return;
-        
+
         if (acpsData.length === 0) {
           throw new Error('No ACPs found. Make sure the submodule is initialized and the build script has been run.');
         }
         setAcps(acpsData);
         setStats(calculateStats(acpsData));
-        setHealth(healthData);
         setError(null);
       } catch (err) {
         if (!mounted) return;
@@ -329,7 +320,6 @@ export default function ACPs() {
   if (loading) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <LoadingSpinner size="lg" />
@@ -348,7 +338,6 @@ export default function ACPs() {
   if (error) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center max-w-md">
             <AlertTriangle className="w-8 h-8 mx-auto mb-4 text-red-600" />
@@ -372,8 +361,6 @@ export default function ACPs() {
   }
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
-      <StatusBar health={health} />
-
       <div className="flex-1">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -4,11 +4,8 @@ import { Search, Filter, Tag, AlertCircle, RefreshCw, TrendingUp, Clock, Calenda
 import { motion, AnimatePresence } from 'framer-motion';
 import { BlogPost, getBlogPosts, getBlogTags, BlogTag } from '../api/blogApi';
 import { BlogCard } from '../components/BlogCard';
-import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
-import { getHealth } from '../api';
-import type { HealthStatus } from '../types';
 
 export function BlogList() {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -23,7 +20,6 @@ export function BlogList() {
     );
     const [hasMore, setHasMore] = useState(false);
     const [loadingMore, setLoadingMore] = useState(false);
-    const [health, setHealth] = useState<HealthStatus | null>(null);
     const [searchSuggestions, setSearchSuggestions] = useState<string[]>([]);
     const [showSuggestions, setShowSuggestions] = useState(false);
 
@@ -112,7 +108,6 @@ export function BlogList() {
     useEffect(() => {
         fetchPosts(0, selectedTag || undefined);
         fetchTags();
-        getHealth().then(setHealth);
     }, [selectedTag]);
 
     const handleTagFilter = (tag: string | null) => {
@@ -185,7 +180,6 @@ export function BlogList() {
     if (loading && posts.length === 0) {
         return (
             <div className="min-h-screen bg-background text-foreground">
-                <StatusBar health={health} />
                 <div className="flex items-center justify-center py-20">
                     <div className="text-center">
                         <LoadingSpinner size="lg" />
@@ -198,8 +192,6 @@ export function BlogList() {
 
     return (
         <div className="min-h-screen flex flex-col bg-background text-foreground">
-            <StatusBar health={health} />
-
             <div className="flex-1">
                 {/* Hero Section */}
                 <div className="relative bg-gradient-to-br from-[#ef4444] via-[#dc2626] to-[#b91c1c] overflow-hidden">

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -22,10 +22,8 @@ import {
 import { BlogPost as BlogPostType, getBlogPost, formatBlogDate, calculateReadTime, getRelatedPosts, RelatedPost } from '../api/blogApi';
 import { getBlogPostImageUrl } from '../utils/imageExtractor';
 import { AuthorCard } from '../components/AuthorCard';
-import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
-import { HealthStatus } from '../types';
 import { RelatedArticles } from '../components/RelatedArticles';
 import { SEO } from '../components/SEO';
 
@@ -174,7 +172,6 @@ export function BlogPost() {
     const [post, setPost] = useState<BlogPostType | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const [health] = useState<HealthStatus | null>(null);
     const [shareMenuOpen, setShareMenuOpen] = useState(false);
     const [isBookmarked, setIsBookmarked] = useState(false);
     const [isLiked, setIsLiked] = useState(false);
@@ -335,7 +332,6 @@ export function BlogPost() {
     if (loading) {
         return (
             <div className="min-h-screen bg-background text-foreground">
-                <StatusBar health={health} />
                 <div className="flex items-center justify-center py-20">
                     <div className="text-center">
                         <LoadingSpinner size="lg" />
@@ -349,7 +345,6 @@ export function BlogPost() {
     if (error) {
         return (
             <div className="min-h-screen bg-background text-foreground">
-                <StatusBar health={health} />
                 <div className="max-w-4xl xl:max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
                     <div className="text-center">
                         <div className="relative inline-block mb-8">
@@ -427,8 +422,6 @@ export function BlogPost() {
                 author={post.author}
                 tags={post.tags}
             />
-
-            <StatusBar health={health} />
 
             {/* Article */}
             <article className="max-w-4xl xl:max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/src/pages/BrandGuidelines 2.tsx
+++ b/src/pages/BrandGuidelines 2.tsx
@@ -6,7 +6,6 @@ import { Typography } from '../components/branding/Typography';
 import { UsageGuidelines } from '../components/branding/UsageGuidelines';
 import { DownloadAssets } from '../components/branding/DownloadAssets';
 import { ExampleApplications } from '../components/branding/ExampleApplications';
-import { StatusBar } from '../components/StatusBar';
 import { useTheme } from '../hooks/useTheme';
 import { Copy, Download, Palette, Type, Layout, Package } from 'lucide-react';
 
@@ -28,8 +27,6 @@ export function BrandGuidelines() {
 
   return (
     <div className="min-h-screen bg-background text-foreground transition-colors">
-      <StatusBar showTabs={false} />
-
       {/* Navigation */}
       <nav className="border-b border-border bg-muted/80 supports-[backdrop-filter]:bg-muted/30 supports-[backdrop-filter]:backdrop-blur-md sticky top-[107px] z-40">
         <div className="max-w-7xl mx-auto px-6">

--- a/src/pages/BrandGuidelines.tsx
+++ b/src/pages/BrandGuidelines.tsx
@@ -6,7 +6,6 @@ import { Typography } from '../components/branding/Typography';
 import { UsageGuidelines } from '../components/branding/UsageGuidelines';
 import { DownloadAssets } from '../components/branding/DownloadAssets';
 import { ExampleApplications } from '../components/branding/ExampleApplications';
-import { StatusBar } from '../components/StatusBar';
 import { useTheme } from '../hooks/useTheme';
 import { Copy, Download, Palette, Type, Layout, Package } from 'lucide-react';
 
@@ -28,8 +27,6 @@ export function BrandGuidelines() {
 
   return (
     <div className="min-h-screen bg-background text-foreground transition-colors">
-      <StatusBar showTabs={false} />
-
       {/* Navigation */}
       <nav className="border-b border-border bg-muted/80 supports-[backdrop-filter]:bg-muted/30 supports-[backdrop-filter]:backdrop-blur-md sticky top-[107px] z-40">
         <div className="max-w-7xl mx-auto px-6">

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
-import { getChains, getTPSHistory, getChainValidators } from '../api';
+import { getChains, getTPSHistory, getChainValidators, getL1BeatFeeMetrics } from '../api';
 import { Chain, TPSHistory } from '../types';
 import {
   Activity,
@@ -50,15 +50,20 @@ export function ChainDetails() {
   const [activeTab, setActiveTab] = useState<'validators' | 'compare'>('validators');
   const [hoveredTab, setHoveredTab] = useState<string | null>(null);
   const [availableChains, setAvailableChains] = useState<Chain[]>([]);
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
 
   useEffect(() => {
     async function fetchData() {
       try {
         setLoading(true);
-        const [chains, healthData] = await Promise.all([
+        const [chains, healthData, feeData] = await Promise.all([
           getChains(),
-          getHealth()
+          getHealth(),
+          getL1BeatFeeMetrics()
         ]);
+        const counts: Record<string, number> = {};
+        feeData.forEach((f) => { counts[f.subnet_id] = f.validator_count; });
+        setValidatorCountBySubnet(counts);
 
         const foundChain = chains.find(c => c.chainId === chainId);
 
@@ -643,6 +648,7 @@ export function ChainDetails() {
                 <ComparisonView
                   currentChain={chain}
                   availableChains={availableChains}
+                  validatorCountBySubnet={validatorCountBySubnet}
                 />
               )}
 

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -23,13 +23,10 @@ import {
   BarChart3
 } from 'lucide-react';
 import { StakeDistributionChart, getValidatorColor } from '../components/StakeDistributionChart';
-import { StatusBar } from '../components/StatusBar';
 import { Footer } from '../components/Footer';
 import { AddToMetaMask } from '../components/AddToMetaMask';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { useTheme } from '../hooks/useTheme';
-import { getHealth } from '../api';
-import { HealthStatus } from '../types';
 import { formatUnits, parseBaseUnits, unitsToNumber } from '../utils/formatUnits';
 import { ComparisonView } from '../components/comparison/ComparisonView';
 
@@ -42,7 +39,6 @@ export function ChainDetails() {
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [showAllValidators, setShowAllValidators] = useState(false);
-  const [health, setHealth] = useState<HealthStatus | null>(null);
   const [sortBy, setSortBy] = useState<'stake' | 'uptime' | 'address'>('stake');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const { theme } = useTheme();
@@ -56,9 +52,8 @@ export function ChainDetails() {
     async function fetchData() {
       try {
         setLoading(true);
-        const [chains, healthData, feeData] = await Promise.all([
+        const [chains, feeData] = await Promise.all([
           getChains(),
-          getHealth(),
           getL1BeatFeeMetrics()
         ]);
         const counts: Record<string, number> = {};
@@ -83,7 +78,6 @@ export function ChainDetails() {
           const apiChainId = foundChain.originalChainId || foundChain.chainId;
           const history = await getTPSHistory(7, apiChainId);
           setTPSHistory(history);
-          setHealth(healthData);
           setError(null);
         } else {
           setError('Chain not found');
@@ -132,7 +126,7 @@ export function ChainDetails() {
   };
 
   const tokenDecimals = chain?.networkToken?.decimals ?? 18;
-  const tokenSymbol = chain?.networkToken?.symbol || 'TOKEN';
+  const tokenSymbol = chain?.networkToken?.symbol || 'N/A';
   // Avalanche staking/validator APIs often represent AVAX in nAVAX (1e9).
   // Even if EVM-native AVAX uses 18 decimals, we should display validator stake using 9 decimals.
   const stakeTokenDecimals = tokenSymbol === 'AVAX' ? 9 : tokenDecimals;
@@ -226,7 +220,6 @@ export function ChainDetails() {
   if (loading) {
     return (
       <div className="min-h-screen bg-background flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <LoadingSpinner size="lg" />
@@ -240,7 +233,6 @@ export function ChainDetails() {
   if (error || !chain) {
     return (
       <div className="min-h-screen bg-background flex flex-col">
-        <StatusBar health={health} />
         <div className="flex-1 flex items-center justify-center p-4">
           <div className="bg-card border border-border rounded-xl shadow-lg p-6 max-w-md w-full text-center">
             <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
@@ -300,8 +292,6 @@ export function ChainDetails() {
 
   return (
     <div className="min-h-screen flex flex-col bg-background">
-      <StatusBar health={health} />
-      
       <div className="flex-1">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
           {/* Header */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatFeeMetrics } from '../api';
-import { Chain, HealthStatus, TeleporterMessageData } from '../types';
+import { getAllChainsTPSLatest, getChains, getCategories, getTeleporterMessages, getL1BeatFeeMetrics } from '../api';
+import { Chain, TeleporterMessageData } from '../types';
 import { ChainCard } from '../components/ChainCard';
 import { ChainListView } from '../components/ChainListView';
 import { ChainTableView } from '../components/ChainTableView';
-import { StatusBar } from '../components/StatusBar';
 import { TVLChart } from '../components/TVLChart';
 import { L1MetricsChart } from '../components/L1MetricsChart';
 import { TeleporterSankeyDiagram } from '../components/TeleporterSankeyDiagram';
@@ -18,13 +17,14 @@ import { motion, AnimatePresence } from 'framer-motion';
 
 export function Dashboard() {
   const [chains, setChains] = useState<Chain[]>([]);
-  const [health, setHealth] = useState<HealthStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [isRefetching, setIsRefetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
+  const [currentPage, setCurrentPage] = useState(1);
+  const CHAINS_PER_PAGE = 20;
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [categories, setCategories] = useState<string[]>([]);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
@@ -47,9 +47,8 @@ export function Dashboard() {
       const filters: { category?: string } = {};
       if (selectedCategory) filters.category = selectedCategory;
 
-      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, feeData] = await Promise.all([
+      const [chainsData, categoriesData, tpsMap, teleporterData, feeData] = await Promise.all([
         getChains(filters),
-        getHealth(),
         getCategories(),
         getAllChainsTPSLatest(),
         getTeleporterMessages(),
@@ -137,7 +136,6 @@ export function Dashboard() {
       });
 
       setChains(sortedChains);
-      setHealth(healthData);
       setCategories(categoriesData);
       setError(null);
     } catch (err) {
@@ -154,13 +152,8 @@ export function Dashboard() {
   }, [selectedCategory, showChainsWithoutValidators]);
 
   useEffect(() => {
-    // Refresh health status every 5 minutes (increased from 1 minute)
-    const healthInterval = setInterval(() => {
-      getHealth().then(setHealth).catch(console.error);
-    }, 5 * 60 * 1000);
-
-    return () => clearInterval(healthInterval);
-  }, []);
+    setCurrentPage(1);
+  }, [searchTerm, selectedCategory, showChainsWithoutValidators, viewMode]);
 
   useEffect(() => {
     // Restore scroll position when returning from chain details
@@ -180,6 +173,12 @@ export function Dashboard() {
   const filteredChains = chains.filter(chain =>
     chain.chainName.toLowerCase().includes(searchTerm.toLowerCase()) ||
     chain.chainId.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const totalPages = Math.ceil(filteredChains.length / CHAINS_PER_PAGE);
+  const paginatedChains = filteredChains.slice(
+    (currentPage - 1) * CHAINS_PER_PAGE,
+    currentPage * CHAINS_PER_PAGE
   );
 
   if (loading) {
@@ -233,8 +232,6 @@ export function Dashboard() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <StatusBar health={health} />
-      
       <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-8 lg:py-12">
         <NetworkMetricsBar />
         
@@ -364,20 +361,74 @@ export function Dashboard() {
               </motion.div>
             ) : (
               <motion.div
-                key={`${viewMode}-${selectedCategory}-${searchTerm}`}
+                key={`${viewMode}-${selectedCategory}-${searchTerm}-${currentPage}`}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
               >
                 {viewMode === 'table' ? (
-                  <ChainTableView chains={filteredChains} icmMessageCounts={icmMessageCounts} validatorCountBySubnet={validatorCountBySubnet} feesBySubnet={feesBySubnet} />
+                  <ChainTableView chains={paginatedChains} icmMessageCounts={icmMessageCounts} validatorCountBySubnet={validatorCountBySubnet} feesBySubnet={feesBySubnet} />
                 ) : (
                   <ChainListView chains={filteredChains} validatorCountBySubnet={validatorCountBySubnet} />
                 )}
               </motion.div>
             )}
           </AnimatePresence>
+
+          {viewMode === 'table' && totalPages > 1 && (
+            <div className="flex items-center justify-between mt-6">
+              <span className="text-sm text-muted-foreground">
+                {(currentPage - 1) * CHAINS_PER_PAGE + 1}–{Math.min(currentPage * CHAINS_PER_PAGE, filteredChains.length)} of {filteredChains.length} chains
+              </span>
+              <div className="flex items-center gap-1">
+                <motion.button
+                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  className="px-3 py-1.5 text-sm border border-border rounded-lg bg-card text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Prev
+                </motion.button>
+                {Array.from({ length: totalPages }, (_, i) => i + 1)
+                  .filter(page => page === 1 || page === totalPages || Math.abs(page - currentPage) <= 1)
+                  .reduce<(number | 'ellipsis')[]>((acc, page, idx, arr) => {
+                    if (idx > 0 && page - (arr[idx - 1] as number) > 1) acc.push('ellipsis');
+                    acc.push(page);
+                    return acc;
+                  }, [])
+                  .map((item, idx) =>
+                    item === 'ellipsis' ? (
+                      <span key={`ellipsis-${idx}`} className="px-2 text-muted-foreground text-sm select-none">…</span>
+                    ) : (
+                      <motion.button
+                        key={item}
+                        onClick={() => setCurrentPage(item as number)}
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        className={`px-3 py-1.5 text-sm border rounded-lg transition-colors ${
+                          currentPage === item
+                            ? 'bg-[#ef4444] border-[#ef4444] text-white'
+                            : 'border-border bg-card text-foreground hover:bg-muted'
+                        }`}
+                      >
+                        {item}
+                      </motion.button>
+                    )
+                  )}
+                <motion.button
+                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  className="px-3 py-1.5 text-sm border border-border rounded-lg bg-card text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Next
+                </motion.button>
+              </div>
+            </div>
+          )}
         </div>
       </main>
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatValidators, getL1BeatFeeMetrics } from '../api';
+import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatFeeMetrics } from '../api';
 import { Chain, HealthStatus, TeleporterMessageData } from '../types';
 import { ChainCard } from '../components/ChainCard';
 import { ChainListView } from '../components/ChainListView';
@@ -47,13 +47,12 @@ export function Dashboard() {
       const filters: { category?: string } = {};
       if (selectedCategory) filters.category = selectedCategory;
 
-      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, validatorData, feeData] = await Promise.all([
+      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, feeData] = await Promise.all([
         getChains(filters),
         getHealth(),
         getCategories(),
         getAllChainsTPSLatest(),
         getTeleporterMessages(),
-        getL1BeatValidators(undefined, true),
         getL1BeatFeeMetrics()
       ]);
 
@@ -69,18 +68,14 @@ export function Dashboard() {
       }
       setIcmMessageCounts(icmCounts);
 
-      // Build validator count map keyed by subnet_id
+      // Build validator count and fee maps from fee metrics (validator_count is included per subnet)
       const validatorCounts: Record<string, number> = {};
-      validatorData.forEach((v) => {
-        validatorCounts[v.subnet_id] = (validatorCounts[v.subnet_id] || 0) + 1;
-      });
-      setValidatorCountBySubnet(validatorCounts);
-
-      // Build fee metrics map keyed by subnet_id (value in nAVAX)
       const feesMap: Record<string, number> = {};
       feeData.forEach((f) => {
+        validatorCounts[f.subnet_id] = f.validator_count;
         feesMap[f.subnet_id] = f.total_fees_paid;
       });
+      setValidatorCountBySubnet(validatorCounts);
       setFeesBySubnet(feesMap);
 
       // Merge latest TPS from bulk endpoint (backend no longer includes tps on /chains)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages } from '../api';
+import { getAllChainsTPSLatest, getChains, getHealth, getCategories, getTeleporterMessages, getL1BeatValidators, getL1BeatFeeMetrics } from '../api';
 import { Chain, HealthStatus, TeleporterMessageData } from '../types';
 import { ChainCard } from '../components/ChainCard';
 import { ChainListView } from '../components/ChainListView';
@@ -30,6 +30,8 @@ export function Dashboard() {
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [showChainsWithoutValidators, setShowChainsWithoutValidators] = useState(false);
   const [icmMessageCounts, setIcmMessageCounts] = useState<Record<string, number>>({});
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
+  const [feesBySubnet, setFeesBySubnet] = useState<Record<string, number>>({});
 
   async function fetchData() {
     try {
@@ -45,12 +47,14 @@ export function Dashboard() {
       const filters: { category?: string } = {};
       if (selectedCategory) filters.category = selectedCategory;
 
-      const [chainsData, healthData, categoriesData, tpsMap, teleporterData] = await Promise.all([
+      const [chainsData, healthData, categoriesData, tpsMap, teleporterData, validatorData, feeData] = await Promise.all([
         getChains(filters),
         getHealth(),
         getCategories(),
         getAllChainsTPSLatest(),
-        getTeleporterMessages()
+        getTeleporterMessages(),
+        getL1BeatValidators(undefined, true),
+        getL1BeatFeeMetrics()
       ]);
 
       // Calculate ICM message counts per chain
@@ -64,6 +68,20 @@ export function Dashboard() {
         });
       }
       setIcmMessageCounts(icmCounts);
+
+      // Build validator count map keyed by subnet_id
+      const validatorCounts: Record<string, number> = {};
+      validatorData.forEach((v) => {
+        validatorCounts[v.subnet_id] = (validatorCounts[v.subnet_id] || 0) + 1;
+      });
+      setValidatorCountBySubnet(validatorCounts);
+
+      // Build fee metrics map keyed by subnet_id (value in nAVAX)
+      const feesMap: Record<string, number> = {};
+      feeData.forEach((f) => {
+        feesMap[f.subnet_id] = f.total_fees_paid;
+      });
+      setFeesBySubnet(feesMap);
 
       // Merge latest TPS from bulk endpoint (backend no longer includes tps on /chains)
       const chainsWithLatestTps = chainsData.map((chain) => {
@@ -95,11 +113,15 @@ export function Dashboard() {
 
       if (!showChainsWithoutValidators) {
         // Default behavior: only show chains with validators or Avalanche primary chains
-        filteredChains = filteredChains.filter(chain =>
-          (chain.validatorCount && chain.validatorCount >= 1) ||
-          chain.chainName.toLowerCase().includes('avalanche') ||
-          chain.chainName.toLowerCase().includes('c-chain')
-        );
+        filteredChains = filteredChains.filter(chain => {
+          const subnetValidators = chain.subnetId ? validatorCounts[chain.subnetId] : undefined;
+          return (
+            (subnetValidators !== undefined && subnetValidators >= 1) ||
+            (chain.validatorCount && chain.validatorCount >= 1) ||
+            chain.chainName.toLowerCase().includes('avalanche') ||
+            chain.chainName.toLowerCase().includes('c-chain')
+          );
+        });
       }
       // If showChainsWithoutValidators is true, include all chains (no validator filter)
 
@@ -354,9 +376,9 @@ export function Dashboard() {
                 transition={{ duration: 0.3 }}
               >
                 {viewMode === 'table' ? (
-                  <ChainTableView chains={filteredChains} icmMessageCounts={icmMessageCounts} />
+                  <ChainTableView chains={filteredChains} icmMessageCounts={icmMessageCounts} validatorCountBySubnet={validatorCountBySubnet} feesBySubnet={feesBySubnet} />
                 ) : (
-                  <ChainListView chains={filteredChains} />
+                  <ChainListView chains={filteredChains} validatorCountBySubnet={validatorCountBySubnet} />
                 )}
               </motion.div>
             )}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -1,24 +1,17 @@
 import { useEffect, useState } from 'react';
-import { StatusBar } from '../components/StatusBar';
 import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
 import { ComparisonView } from '../components/comparison';
 import { Footer } from '../components/Footer';
-import { getHealth, getL1BeatFeeMetrics } from '../api';
-import { HealthStatus } from '../types';
+import { getL1BeatFeeMetrics } from '../api';
 
 export function Metrics() {
-  const [health, setHealth] = useState<HealthStatus | null>(null);
   const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
 
   useEffect(() => {
     async function fetchData() {
       try {
-        const [healthData, feeData] = await Promise.all([
-          getHealth(),
-          getL1BeatFeeMetrics()
-        ]);
-        setHealth(healthData);
+        const feeData = await getL1BeatFeeMetrics();
         const counts: Record<string, number> = {};
         feeData.forEach((f) => { counts[f.subnet_id] = f.validator_count; });
         setValidatorCountBySubnet(counts);
@@ -32,7 +25,6 @@ export function Metrics() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <StatusBar health={health} />
 
       <main className="max-w-7xl mx-auto px-6 py-12 space-y-12">
         {/* Network-Wide Metrics */}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -4,23 +4,30 @@ import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
 import { ComparisonView } from '../components/comparison';
 import { Footer } from '../components/Footer';
-import { getHealth } from '../api';
+import { getHealth, getL1BeatFeeMetrics } from '../api';
 import { HealthStatus } from '../types';
 
 export function Metrics() {
   const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
 
   useEffect(() => {
-    async function fetchHealth() {
+    async function fetchData() {
       try {
-        const healthData = await getHealth();
+        const [healthData, feeData] = await Promise.all([
+          getHealth(),
+          getL1BeatFeeMetrics()
+        ]);
         setHealth(healthData);
+        const counts: Record<string, number> = {};
+        feeData.forEach((f) => { counts[f.subnet_id] = f.validator_count; });
+        setValidatorCountBySubnet(counts);
       } catch (err) {
-        console.error('Failed to fetch health:', err);
+        console.error('Failed to fetch data:', err);
       }
     }
 
-    fetchHealth();
+    fetchData();
   }, []);
 
   return (
@@ -36,7 +43,7 @@ export function Metrics() {
 
         {/* Chain Comparison */}
         <section>
-          <ComparisonView />
+          <ComparisonView validatorCountBySubnet={validatorCountBySubnet} />
         </section>
       </main>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,22 +198,6 @@ export interface HealthStatus {
 }
 
 // L1Beat external API types (https://api.l1beat.io)
-export interface L1BeatValidatorRecord {
-  subnet_id: string;
-  validation_id: string;
-  node_id: string;
-  balance: number;
-  weight: number;
-  start_time: string;
-  end_time: string;
-  uptime_percentage: number;
-  active: boolean;
-  initial_deposit: number;
-  total_topups: number;
-  refund_amount: number;
-  fees_paid: number;
-}
-
 export interface L1BeatFeeMetrics {
   subnet_id: string;
   total_deposited: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,12 +451,3 @@ export interface ACPSearchResponse extends ACPListResponse {
   suggestions?: string[];
 }
 
-// ============= CHAIN COMPARISON TYPES =============
-
-export interface ChainComparisonData {
-  chain: Chain;
-  tpsHistory: TPSHistory[];
-  cumulativeTx: CumulativeTxCount[];
-}
-
-export type ComparisonMetricType = 'tps' | 'transactions';

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,40 @@ export interface HealthStatus {
   timestamp: number;
 }
 
+// L1Beat external API types (https://api.l1beat.io)
+export interface L1BeatValidatorRecord {
+  subnet_id: string;
+  validation_id: string;
+  node_id: string;
+  balance: number;
+  weight: number;
+  start_time: string;
+  end_time: string;
+  uptime_percentage: number;
+  active: boolean;
+  initial_deposit: number;
+  total_topups: number;
+  refund_amount: number;
+  fees_paid: number;
+}
+
+export interface L1BeatFeeMetrics {
+  subnet_id: string;
+  total_deposited: number;
+  initial_deposits: number;
+  top_up_deposits: number;
+  total_refunded: number;
+  current_balance: number;
+  total_fees_paid: number;
+  deposit_tx_count: number;
+  validator_count: number;
+}
+
+export interface L1BeatApiMeta {
+  limit: number;
+  offset: number;
+}
+
 // Teleporter message types
 export interface TeleporterMessage {
   source: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,11 +226,6 @@ export interface L1BeatFeeMetrics {
   validator_count: number;
 }
 
-export interface L1BeatApiMeta {
-  limit: number;
-  offset: number;
-}
-
 // Teleporter message types
 export interface TeleporterMessage {
   source: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,11 +10,13 @@ export default defineConfig(async ({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), '');
   const apiBaseUrl = env.VITE_API_BASE_URL;
+  const l1beatExternalApi = env.VITE_L1BEAT_EXTERNAL_API;
 
   return {
     define: {
       'process.env': {},
       'import.meta.env.VITE_API_BASE_URL': JSON.stringify(apiBaseUrl),
+      'import.meta.env.VITE_L1BEAT_EXTERNAL_API': JSON.stringify(l1beatExternalApi),
     },
     plugins: [
       react(),


### PR DESCRIPTION
  Integrate validators & fees data from L1Beat API
                                                                                                                                                                                          
  Summary                                                                                                                                                                               
                                         
  - Replaces chain.validatorCount (from the generic /api/chains backend endpoint) with live active validator counts sourced from https://api.l1beat.io/api/v1/metrics/fees — the fee
  metrics response includes validator_count per subnet, so no separate validators endpoint call is needed
  - Replaces the "Coming Soon" placeholder in the Fees to P-Chain column with the actual total_fees_paid value from /api/v1/metrics/fees, converted from nAVAX to AVAX and formatted with
  K/M abbreviations
  - Makes the Fees to P-Chain column sortable
  - Wires validatorCountBySubnet into ComparisonView on both /metrics and /chain/:id — it was always receiving {}