### PR TITLE
feat: redesign chain comparison and validator details pages

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,14 @@ import type { Chain, TVLHistory, TVLHealth, NetworkTPS, TPSHistory, HealthStatus
 import type { DailyActiveAddresses } from './types';
 import { config } from './config';
 
+// Filter predicate to exclude today's partial data from time-series arrays.
+// Data for the current day is incomplete and causes misleading dips in charts.
+function isNotToday(d: { timestamp: number }): boolean {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime() / 1000;
+  return d.timestamp < todayStart;
+}
+
 // XSS protection - sanitize strings in API responses
 // Only encode < and > to prevent HTML tag injection. React already escapes
 // attribute values and text nodes, so encoding & / " / ' here would
@@ -489,7 +497,7 @@ export async function getTPSHistory(days: number = 7, chainId?: string): Promise
           chainCount: Number(item.chainCount || 1),
           date: item.timestamp
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('TPS history fetch error:', error);
       return [];
@@ -510,7 +518,7 @@ export async function getCumulativeTxCount(chainId: string, days: number = 7): P
       }
 
       return response.data
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Cumulative transaction count fetch error:', error);
       return [];
@@ -705,7 +713,7 @@ export async function getNetworkMaxTPSHistory(days: number = 30): Promise<MaxTPS
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network max TPS history fetch error:', error);
       return [];
@@ -734,7 +742,7 @@ export async function getChainMaxTPSHistory(chainId: string, days: number = 30):
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Chain max TPS history fetch error:', error);
       return [];
@@ -765,7 +773,7 @@ export async function getDailyMessageVolumeFromExternal(days: number = 30): Prom
           timestamp: Math.floor(new Date(item.date).getTime() / 1000),
           value: Number(item.messageCount || item.count || item.value || 0)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Daily message volume fetch error:', error);
       return [];
@@ -842,7 +850,7 @@ export async function getNetworkTxCountHistory(days: number = 30): Promise<Daily
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network tx count history fetch error:', error);
       return [];
@@ -871,7 +879,7 @@ export async function getChainTxCountHistory(chainId: string, days: number = 30)
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Chain tx count history fetch error:', error);
       return [];
@@ -900,7 +908,7 @@ export async function getNetworkGasUsedHistory(days: number = 30): Promise<GasUs
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network gas used history fetch error:', error);
       return [];
@@ -929,7 +937,7 @@ export async function getChainGasUsedHistory(chainId: string, days: number = 30)
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Chain gas used history fetch error:', error);
       return [];
@@ -1036,7 +1044,7 @@ export async function getNetworkAvgGasPriceHistory(days: number = 30): Promise<A
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network avg gas price history fetch error:', error);
       return [];
@@ -1075,7 +1083,7 @@ export async function getChainAvgGasPriceHistory(chainId: string, days: number =
             value: value
           };
         })
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Chain avg gas price history fetch error:', error);
       return [];
@@ -1159,7 +1167,7 @@ export async function getChainFeesPaidHistory(chainId: string, days: number = 30
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Chain fees paid history fetch error:', error);
       return [];
@@ -1212,7 +1220,7 @@ export async function getNetworkFeesPaidHistory(days: number = 30): Promise<Fees
           timestamp: Number(item.timestamp),
           value: Number(item.value)
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network fees paid history fetch error:', error);
       return [];
@@ -1266,7 +1274,7 @@ export async function getNetworkActiveAddressesHistory(days: number = 30): Promi
           activeAddresses: Number(item.value),
           transactions: 0 // API doesn't provide transactions count yet
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Network active addresses history fetch error:', error);
       return [];
@@ -1296,7 +1304,7 @@ export async function getDailyActiveAddresses(chainId: string, days: number = 30
           activeAddresses: Number(item.value),
           transactions: 0 // API doesn't provide transactions count yet
         }))
-        .sort((a, b) => a.timestamp - b.timestamp);
+        .sort((a, b) => a.timestamp - b.timestamp).filter(isNotToday);
     } catch (error) {
       console.error('Daily active addresses fetch error:', error);
       return [];

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -1,12 +1,11 @@
-import { memo, useState, useEffect, useCallback, useRef } from 'react';
+import { memo, useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Chain, DailyTxCount, DailyActiveAddresses, MaxTPSHistory, GasUsedHistory, AvgGasPriceHistory, FeesPaidHistory } from '../../types';
-import { Plus, X, Trash2, BarChart3, Share2, ChevronDown } from 'lucide-react';
+import { Chain, DailyTxCount, DailyActiveAddresses, MaxTPSHistory, GasUsedHistory, AvgGasPriceHistory, FeesPaidHistory, L1BeatFeeMetrics } from '../../types';
+import { Plus, X, Trash2, Share2, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChainSelector } from './ChainSelector';
-import { ComparisonMetricsTable } from './ComparisonMetricsTable';
 import { ComparisonChart, ComparisonMetricType } from './ComparisonChart';
-import { getDailyActiveAddresses, getChainTxCountHistory, getChainMaxTPSHistory, getChainGasUsedHistory, getChainAvgGasPriceHistory, getChainFeesPaidHistory, getChains } from '../../api';
+import { getDailyActiveAddresses, getChainTxCountHistory, getChainMaxTPSHistory, getChainGasUsedHistory, getChainAvgGasPriceHistory, getChainFeesPaidHistory, getChains, getL1BeatFeeMetrics } from '../../api';
 import { LoadingSpinner } from '../LoadingSpinner';
 
 interface ComparisonViewProps {
@@ -23,17 +22,32 @@ interface ChainComparisonData {
   gasUsed: GasUsedHistory[];
   avgGasPrice: AvgGasPriceHistory[];
   feesPaid: FeesPaidHistory[];
+  feeMetrics: L1BeatFeeMetrics | null;
   loading: boolean;
 }
 
-const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; valueLabel: string }[] = [
-  { id: 'dailyActiveAddresses', name: 'Daily Active Addresses', valueLabel: 'addresses' },
-  { id: 'dailyTxCount', name: 'Daily Transaction Count', valueLabel: 'transactions' },
-  { id: 'maxTPS', name: 'Daily Max TPS', valueLabel: 'TPS' },
-  { id: 'gasUsed', name: 'Daily Gas Used', valueLabel: 'gas' },
-  { id: 'avgGasPrice', name: 'Daily Avg Gas Price', valueLabel: '' },
-  { id: 'feesPaid', name: 'Daily Fees Paid', valueLabel: '' },
+const CHAIN_COLORS = [
+  { border: 'border-indigo-500', bg: 'bg-indigo-500', bgFaint: 'bg-indigo-500/10', dot: 'bg-indigo-500', barTrack: 'bg-indigo-500/20', text: 'text-indigo-400' },
+  { border: 'border-emerald-500', bg: 'bg-emerald-500', bgFaint: 'bg-emerald-500/10', dot: 'bg-emerald-500', barTrack: 'bg-emerald-500/20', text: 'text-emerald-400' },
+  { border: 'border-amber-500', bg: 'bg-amber-500', bgFaint: 'bg-amber-500/10', dot: 'bg-amber-500', barTrack: 'bg-amber-500/20', text: 'text-amber-400' },
+  { border: 'border-red-500', bg: 'bg-red-500', bgFaint: 'bg-red-500/10', dot: 'bg-red-500', barTrack: 'bg-red-500/20', text: 'text-red-400' },
 ];
+
+const COMPARISON_METRICS: { id: ComparisonMetricType; name: string; shortName: string; valueLabel: string }[] = [
+  { id: 'dailyActiveAddresses', name: 'Daily Active Addresses', shortName: 'Active Addresses', valueLabel: 'addresses' },
+  { id: 'dailyTxCount', name: 'Daily Transaction Count', shortName: 'Transactions', valueLabel: 'transactions' },
+  { id: 'maxTPS', name: 'Daily Max TPS', shortName: 'Max TPS', valueLabel: 'TPS' },
+  { id: 'gasUsed', name: 'Daily Gas Used', shortName: 'Gas Used', valueLabel: 'gas' },
+  { id: 'feesPaid', name: 'Daily Fees Paid', shortName: 'Fees Paid', valueLabel: '' },
+];
+
+function formatCompact(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  if (value < 1 && value > 0) return value.toFixed(2);
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
 
 export const ComparisonView = memo(function ComparisonView({
   currentChain,
@@ -47,154 +61,102 @@ export const ComparisonView = memo(function ComparisonView({
   const [chainsLoading, setChainsLoading] = useState(!providedChains);
   const [urlInitialized, setUrlInitialized] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [metricDropdownOpen, setMetricDropdownOpen] = useState(false);
-  const metricDropdownRef = useRef<HTMLDivElement>(null);
 
-  // Read selected metric from URL or default
   const metricParam = searchParams.get('metric');
   const selectedMetric: ComparisonMetricType = COMPARISON_METRICS.some(m => m.id === metricParam)
     ? metricParam as ComparisonMetricType
     : 'dailyActiveAddresses';
 
-  // Read timeframe from URL or default to 7
   const timeframeParam = searchParams.get('timeframe');
   const timeframe = (timeframeParam === '30' ? 30 : 7) as 7 | 30;
 
-  // Keep a ref to the latest searchParams so updateUrl never captures stale values
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
 
-  // Update URL with current state. Always writes both timeframe and metric so
-  // that partial updates (e.g. changing only the metric) don't silently drop
-  // the other param and break shareable URLs.
   const updateUrl = useCallback((chainIds: string[], newTimeframe?: number, newMetric?: ComparisonMetricType) => {
     const newParams = new URLSearchParams(searchParamsRef.current);
-
     if (chainIds.length > 0) {
       newParams.set('compare', chainIds.join(','));
     } else {
       newParams.delete('compare');
     }
-
     newParams.set('timeframe', String(newTimeframe ?? timeframe));
     newParams.set('metric', newMetric ?? selectedMetric);
-
     setSearchParams(newParams, { replace: true });
   }, [setSearchParams, timeframe, selectedMetric]);
 
-  // Close metric dropdown on outside click
-  useEffect(() => {
-    if (!metricDropdownOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (metricDropdownRef.current && !metricDropdownRef.current.contains(e.target as Node)) {
-        setMetricDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [metricDropdownOpen]);
-
-  // Handle timeframe change
   const handleTimeframeChange = useCallback((newTimeframe: 7 | 30) => {
     const chainIds = comparisonChains.map(c => c.chain.chainId);
     updateUrl(chainIds, newTimeframe);
   }, [comparisonChains, updateUrl]);
 
-  // Handle metric change
   const handleMetricChange = useCallback((metric: ComparisonMetricType) => {
     const chainIds = comparisonChains.map(c => c.chain.chainId);
     updateUrl(chainIds, undefined, metric);
-    setMetricDropdownOpen(false);
   }, [comparisonChains, updateUrl]);
 
-  // Copy share URL to clipboard
   const handleCopyShareUrl = useCallback(() => {
-    const url = window.location.href;
-    navigator.clipboard.writeText(url).then(() => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    }).catch(() => {
-      console.warn('Clipboard write failed');
-    });
+    }).catch(() => {});
   }, []);
 
-  // Fetch available chains if not provided
   useEffect(() => {
+    const filterChains = (chains: Chain[]) =>
+      chains
+        .filter(chain => chain.validatorCount && chain.validatorCount >= 1 && chain.network === 'mainnet')
+        .filter(chain => { const name = chain.chainName.toLowerCase(); return !name.includes('x-chain') && !name.includes('p-chain'); });
+
     if (providedChains) {
-      setAvailableChains(providedChains);
+      setAvailableChains(filterChains(providedChains));
       setChainsLoading(false);
       return;
     }
-
     async function fetchAvailableChains() {
       setChainsLoading(true);
       try {
-        const chains = await getChains();
-        const filteredChains = chains.filter(chain =>
-          (chain.validatorCount && chain.validatorCount >= 1) ||
-          chain.chainName.toLowerCase().includes('avalanche') ||
-          chain.chainName.toLowerCase().includes('c-chain')
-        );
-        const excludedChains = filteredChains.filter(chain => {
-          const name = chain.chainName.toLowerCase();
-          return !name.includes('x-chain') && !name.includes('p-chain');
-        });
-        const sortedChains = excludedChains.sort((a, b) => {
-          const nameA = a.chainName.toLowerCase();
-          const nameB = b.chainName.toLowerCase();
-          const isCChainA = nameA.includes('c-chain');
-          const isCChainB = nameB.includes('c-chain');
-          if (isCChainA && !isCChainB) return -1;
-          if (!isCChainA && isCChainB) return 1;
-          return a.chainName.localeCompare(b.chainName);
-        });
-        setAvailableChains(sortedChains);
+        const chains = await getChains({ network: 'mainnet' });
+        const filtered = filterChains(chains)
+          .sort((a, b) => {
+            const isCChainA = a.chainName.toLowerCase().includes('c-chain');
+            const isCChainB = b.chainName.toLowerCase().includes('c-chain');
+            if (isCChainA && !isCChainB) return -1;
+            if (!isCChainA && isCChainB) return 1;
+            return a.chainName.localeCompare(b.chainName);
+          });
+        setAvailableChains(filtered);
       } catch (error) {
         console.error('Failed to fetch chains:', error);
       } finally {
         setChainsLoading(false);
       }
     }
-
     fetchAvailableChains();
   }, [providedChains]);
 
-  // Fetch all 6 metric types for a chain. Keyed by chainId (not positional
-  // index) so that concurrent adds don't overwrite each other's slots when
-  // React state hasn't committed yet.
   const fetchChainData = useCallback(async (chain: Chain) => {
     const targetChainId = chain.chainId;
     try {
       const apiChainId = chain.originalChainId || chain.chainId;
       const evmChainIdStr = chain.evmChainId ? String(chain.evmChainId) : apiChainId;
-
-      const [activeAddresses, dailyTx, maxTps, gasUsedData, avgGasPriceData, feesPaidData] = await Promise.all([
+      const [activeAddresses, dailyTx, maxTps, gasUsedData, avgGasPriceData, feesPaidData, feeMetricsData] = await Promise.all([
         getDailyActiveAddresses(evmChainIdStr, timeframe).catch(() => []),
         getChainTxCountHistory(apiChainId, timeframe).catch(() => []),
         getChainMaxTPSHistory(apiChainId, timeframe).catch(() => []),
         getChainGasUsedHistory(apiChainId, timeframe).catch(() => []),
         getChainAvgGasPriceHistory(apiChainId, timeframe).catch(() => []),
-        getChainFeesPaidHistory(apiChainId, timeframe).catch(() => [])
+        getChainFeesPaidHistory(apiChainId, timeframe).catch(() => []),
+        chain.subnetId ? getL1BeatFeeMetrics(chain.subnetId).then(r => r[0] ?? null).catch(() => null) : Promise.resolve(null),
       ]);
-
       setComparisonChains(prev => {
         const idx = prev.findIndex(c => c.chain.chainId === targetChainId);
-        if (idx === -1) return prev; // chain was removed while loading
+        if (idx === -1) return prev;
         const updated = [...prev];
-        updated[idx] = {
-          chain,
-          dailyActiveAddresses: activeAddresses,
-          dailyTxCount: dailyTx,
-          maxTPS: maxTps,
-          gasUsed: gasUsedData,
-          avgGasPrice: avgGasPriceData,
-          feesPaid: feesPaidData,
-          loading: false
-        };
+        updated[idx] = { chain, dailyActiveAddresses: activeAddresses, dailyTxCount: dailyTx, maxTPS: maxTps, gasUsed: gasUsedData, avgGasPrice: avgGasPriceData, feesPaid: feesPaidData, feeMetrics: feeMetricsData, loading: false };
         return updated;
       });
-    } catch (error) {
-      console.error('Failed to fetch chain data:', error);
+    } catch {
       setComparisonChains(prev => {
         const idx = prev.findIndex(c => c.chain.chainId === targetChainId);
         if (idx === -1) return prev;
@@ -205,94 +167,44 @@ export const ComparisonView = memo(function ComparisonView({
     }
   }, [timeframe]);
 
-  // Initialize comparison chains from URL params after chains are loaded
   useEffect(() => {
     if (chainsLoading || urlInitialized || availableChains.length === 0) return;
-
     const compareParam = searchParams.get('compare');
     if (compareParam) {
       const chainIds = compareParam.split(',').filter(Boolean).slice(0, 4);
       const initialChains: ChainComparisonData[] = [];
-
       chainIds.forEach(chainId => {
         const chain = availableChains.find(c => c.chainId === chainId);
         if (chain) {
-          initialChains.push({
-            chain,
-            dailyActiveAddresses: [],
-            dailyTxCount: [],
-            maxTPS: [],
-            gasUsed: [],
-            avgGasPrice: [],
-            feesPaid: [],
-            loading: true
-          });
+          initialChains.push({ chain, dailyActiveAddresses: [], dailyTxCount: [], maxTPS: [], gasUsed: [], avgGasPrice: [], feesPaid: [], feeMetrics: null, loading: true });
         }
       });
-
       if (initialChains.length > 0) {
         setComparisonChains(initialChains);
-        initialChains.forEach((data) => {
-          fetchChainData(data.chain);
-        });
+        initialChains.forEach(data => fetchChainData(data.chain));
       }
     } else if (currentChain) {
-      setComparisonChains([{
-        chain: currentChain,
-        dailyActiveAddresses: [],
-        dailyTxCount: [],
-        maxTPS: [],
-        gasUsed: [],
-        avgGasPrice: [],
-        feesPaid: [],
-        loading: true
-      }]);
+      setComparisonChains([{ chain: currentChain, dailyActiveAddresses: [], dailyTxCount: [], maxTPS: [], gasUsed: [], avgGasPrice: [], feesPaid: [], feeMetrics: null, loading: true }]);
       fetchChainData(currentChain);
       updateUrl([currentChain.chainId]);
     }
-
     setUrlInitialized(true);
   }, [chainsLoading, availableChains, urlInitialized, searchParams, currentChain, fetchChainData, updateUrl]);
 
-  // Track previous timeframe to detect changes
   const prevTimeframeRef = useRef(timeframe);
-
-  // Refetch data when timeframe changes
   useEffect(() => {
     if (prevTimeframeRef.current === timeframe) return;
     prevTimeframeRef.current = timeframe;
-
-    setComparisonChains(prev => {
-      if (prev.length === 0) return prev;
-      return prev.map(c => ({ ...c, loading: true }));
-    });
-
-    comparisonChains.forEach((data) => {
-      fetchChainData(data.chain);
-    });
+    setComparisonChains(prev => prev.length === 0 ? prev : prev.map(c => ({ ...c, loading: true })));
+    comparisonChains.forEach(data => fetchChainData(data.chain));
   }, [timeframe, fetchChainData]);
 
   const handleAddChain = (chain: Chain) => {
     if (comparisonChains.length >= 4) return;
     if (comparisonChains.some(c => c.chain.chainId === chain.chainId)) return;
-
-    const newChains = [
-      ...comparisonChains,
-      {
-        chain,
-        dailyActiveAddresses: [],
-        dailyTxCount: [],
-        maxTPS: [],
-        gasUsed: [],
-        avgGasPrice: [],
-        feesPaid: [],
-        loading: true
-      }
-    ];
+    const newChains = [...comparisonChains, { chain, dailyActiveAddresses: [], dailyTxCount: [], maxTPS: [], gasUsed: [], avgGasPrice: [], feesPaid: [], feeMetrics: null, loading: true }];
     setComparisonChains(newChains);
-
     updateUrl(newChains.map(c => c.chain.chainId));
-
     fetchChainData(chain);
     setIsModalOpen(false);
   };
@@ -300,7 +212,6 @@ export const ComparisonView = memo(function ComparisonView({
   const handleRemoveChain = (chainId: string) => {
     const newChains = comparisonChains.filter(c => c.chain.chainId !== chainId);
     setComparisonChains(newChains);
-
     updateUrl(newChains.map(c => c.chain.chainId));
   };
 
@@ -312,17 +223,39 @@ export const ComparisonView = memo(function ComparisonView({
   const selectedChainIds = comparisonChains.map(c => c.chain.chainId);
   const canAddMore = comparisonChains.length < 4;
   const hasMultipleChains = comparisonChains.length >= 2;
-  const hasAnyChains = comparisonChains.length > 0;
 
   const currentMetricConfig = COMPARISON_METRICS.find(m => m.id === selectedMetric) || COMPARISON_METRICS[0];
 
+  // Compute per-chain stats for cards
+  const NAVAX_TO_AVAX = 1_000_000_000;
+
+  const chainStats = useMemo(() => {
+    const stats = comparisonChains.map(data => {
+      const maxTps = data.maxTPS.length > 0 ? data.maxTPS[data.maxTPS.length - 1].value : 0;
+      const validators = (data.chain.subnetId ? validatorCountBySubnet[data.chain.subnetId] : undefined) ?? data.chain.validatorCount ?? 0;
+      const dailyTx = data.dailyTxCount.length > 0 ? data.dailyTxCount[data.dailyTxCount.length - 1].value : 0;
+      const totalFeesPaid = data.feeMetrics ? data.feeMetrics.total_fees_paid / NAVAX_TO_AVAX : 0;
+      const totalDeposited = data.feeMetrics ? data.feeMetrics.total_deposited / NAVAX_TO_AVAX : 0;
+      const currentBalance = data.feeMetrics ? data.feeMetrics.current_balance / NAVAX_TO_AVAX : 0;
+      return { maxTps, validators, dailyTx, totalFeesPaid, totalDeposited, currentBalance, hasFeeData: !!data.feeMetrics, loading: data.loading };
+    });
+    const maxTps = Math.max(...stats.map(s => s.maxTps), 0);
+    const maxValidators = Math.max(...stats.map(s => s.validators), 0);
+    const maxDailyTx = Math.max(...stats.map(s => s.dailyTx), 0);
+    const maxFees = Math.max(...stats.map(s => s.totalFeesPaid), 0);
+    return stats.map(s => ({
+      ...s,
+      tpsPercent: maxTps > 0 ? (s.maxTps / maxTps) * 100 : 0,
+      isBestTps: s.maxTps === maxTps && maxTps > 0,
+      isBestValidators: s.validators === maxValidators && maxValidators > 0,
+      isBestDailyTx: s.dailyTx === maxDailyTx && maxDailyTx > 0,
+      isMostFees: s.totalFeesPaid === maxFees && maxFees > 0,
+    }));
+  }, [comparisonChains, validatorCountBySubnet]);
+
   if (chainsLoading) {
     return (
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="bg-card border border-border rounded-xl p-12 flex flex-col items-center justify-center"
-      >
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="bg-card border border-border rounded-xl p-12 flex flex-col items-center justify-center">
         <LoadingSpinner size="lg" />
         <p className="mt-4 text-muted-foreground">Loading chains...</p>
       </motion.div>
@@ -330,292 +263,230 @@ export const ComparisonView = memo(function ComparisonView({
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header with Actions */}
-      <div className="bg-card border border-border rounded-xl p-6">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-bold text-foreground flex items-center gap-2">
-              <BarChart3 className="w-5 h-5 text-[#ef4444]" />
-              Chain Comparison
-            </h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              {comparisonChains.length === 0
-                ? 'Select chains to compare performance metrics'
-                : comparisonChains.length === 1
-                ? 'Add more chains to compare'
-                : `Comparing ${comparisonChains.length} chains`}
-            </p>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <AnimatePresence>
-              {hasAnyChains && (
-                <motion.button
-                  initial={{ scale: 0, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0, opacity: 0 }}
-                  transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-                  onClick={handleClearAll}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted transition-all"
-                >
-                  <Trash2 className="w-4 h-4" />
-                  Clear All
-                </motion.button>
-              )}
-            </AnimatePresence>
-
-            <motion.button
-              onClick={() => setIsModalOpen(!isModalOpen)}
-              disabled={!canAddMore}
-              whileHover={canAddMore ? { scale: 1.05 } : {}}
-              whileTap={canAddMore ? { scale: 0.95 } : {}}
-              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
-                isModalOpen
-                  ? 'bg-[#dc2626] text-white'
-                  : canAddMore
-                  ? 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
-                  : 'bg-muted text-muted-foreground cursor-not-allowed'
-              }`}
-            >
-              {isModalOpen ? <X className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
-              {isModalOpen ? 'Close' : 'Add Chain'}
-            </motion.button>
-          </div>
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Compare Chains</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {comparisonChains.length === 0
+              ? 'Select up to 4 L1s to compare performance metrics'
+              : comparisonChains.length === 1
+              ? 'Add more chains to start comparing'
+              : `Comparing ${comparisonChains.length} chains`}
+          </p>
         </div>
-
-        {/* Selected Chains Pills */}
-        <AnimatePresence>
-          {hasAnyChains && (
-            <motion.div
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: 'auto', opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
-              className="overflow-hidden"
-            >
-              <div className="mt-4 pt-4 border-t border-border">
-                <div className="flex flex-wrap gap-2">
-                  <AnimatePresence mode="popLayout">
-                    {comparisonChains.map((data, index) => (
-                      <motion.div
-                        key={data.chain.chainId}
-                        layout
-                        initial={{ scale: 0, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0, opacity: 0 }}
-                        transition={{
-                          type: "spring",
-                          stiffness: 500,
-                          damping: 30,
-                          delay: index * 0.05
-                        }}
-                        className="flex items-center gap-2 px-3 py-2 bg-muted rounded-lg border border-border"
-                      >
-                        {data.chain.chainLogoUri ? (
-                          <img
-                            src={data.chain.chainLogoUri}
-                            alt={`${data.chain.chainName} logo`}
-                            className="w-5 h-5 rounded"
-                            onError={(e) => {
-                              e.currentTarget.src = "/icon-dark-animated.svg";
-                              e.currentTarget.onerror = null;
-                            }}
-                          />
-                        ) : (
-                          <img
-                            src="/icon-dark-animated.svg"
-                            alt={`${data.chain.chainName} logo`}
-                            className="w-5 h-5 rounded"
-                          />
-                        )}
-                        <span className="text-sm font-medium text-foreground">
-                          {data.chain.chainName}
-                        </span>
-                        <motion.button
-                          onClick={() => handleRemoveChain(data.chain.chainId)}
-                          whileHover={{ scale: 1.2, rotate: 90 }}
-                          whileTap={{ scale: 0.9 }}
-                          className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors"
-                        >
-                          <X className="w-4 h-4 text-muted-foreground" />
-                        </motion.button>
-                      </motion.div>
-                    ))}
-                  </AnimatePresence>
-                </div>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <div className="flex items-center gap-2.5">
+          <AnimatePresence>
+            {comparisonChains.length > 0 && (
+              <motion.button
+                initial={{ scale: 0, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0, opacity: 0 }}
+                onClick={handleClearAll}
+                className="flex items-center gap-2 px-3.5 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted transition-all"
+              >
+                <Trash2 className="w-3.5 h-3.5" /> Clear All
+              </motion.button>
+            )}
+          </AnimatePresence>
+          <motion.button
+            onClick={() => setIsModalOpen(!isModalOpen)}
+            disabled={!canAddMore}
+            whileHover={canAddMore ? { scale: 1.03 } : {}}
+            whileTap={canAddMore ? { scale: 0.97 } : {}}
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all ${
+              canAddMore ? 'bg-[#ef4444] text-white hover:bg-[#dc2626]' : 'bg-muted text-muted-foreground cursor-not-allowed'
+            }`}
+          >
+            <Plus className="w-4 h-4" /> Add Chain
+          </motion.button>
+        </div>
       </div>
 
-      {/* Comparison Content */}
+      {/* Chain Stat Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <AnimatePresence mode="popLayout">
+          {comparisonChains.map((data, index) => {
+            const color = CHAIN_COLORS[index % CHAIN_COLORS.length];
+            const stats = chainStats[index];
+            return (
+              <motion.div
+                key={data.chain.chainId}
+                layout
+                initial={{ scale: 0.9, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.9, opacity: 0 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 28, delay: index * 0.05 }}
+                className={`bg-card rounded-xl border ${color.border} p-4 flex flex-col gap-3.5`}
+              >
+                {/* Card Header */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2.5">
+                    <div className={`w-2.5 h-2.5 rounded-full ${color.dot}`} />
+                    <span className="text-sm font-semibold text-foreground">{data.chain.chainName}</span>
+                  </div>
+                  <motion.button
+                    onClick={() => handleRemoveChain(data.chain.chainId)}
+                    whileHover={{ scale: 1.2, rotate: 90 }}
+                    whileTap={{ scale: 0.9 }}
+                    className="p-0.5 rounded hover:bg-muted transition-colors"
+                  >
+                    <X className="w-3.5 h-3.5 text-muted-foreground" />
+                  </motion.button>
+                </div>
+
+                {/* Stats */}
+                {stats?.loading ? (
+                  <div className="flex items-center justify-center py-4">
+                    <Loader2 className="w-5 h-5 text-muted-foreground animate-spin" />
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">Max TPS</span>
+                      <span className={`text-xs font-semibold ${stats?.isBestTps ? 'text-green-500' : 'text-foreground'}`}>
+                        {stats ? (stats.maxTps < 1 && stats.maxTps > 0 ? '< 1.0' : stats.maxTps.toFixed(2)) : '–'}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">Validators</span>
+                      <span className={`text-xs font-semibold ${stats?.isBestValidators ? 'text-green-500' : 'text-foreground'}`}>
+                        {stats?.validators.toLocaleString() ?? '–'}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">Daily Tx</span>
+                      <span className={`text-xs font-semibold ${stats?.isBestDailyTx ? 'text-green-500' : 'text-foreground'}`}>
+                        {stats ? formatCompact(stats.dailyTx) : '–'}
+                      </span>
+                    </div>
+                    {stats?.hasFeeData && (
+                      <>
+                        <div className="border-t border-border/50 my-1" />
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs text-muted-foreground">Fees Burned 🔥</span>
+                          <span className={`text-xs font-semibold ${stats.isMostFees ? 'text-red-500' : 'text-foreground'}`}>
+                            {formatCompact(stats.totalFeesPaid)} AVAX
+                          </span>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+
+                {/* Activity Bar */}
+                <div className={`h-1 w-full rounded-full ${color.barTrack}`}>
+                  <motion.div
+                    className={`h-full rounded-full ${color.bg}`}
+                    initial={{ width: 0 }}
+                    animate={{ width: `${stats?.tpsPercent ?? 0}%` }}
+                    transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
+                  />
+                </div>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+
+        {/* Add Chain Placeholder Card(s) */}
+        {canAddMore && (
+          <motion.button
+            onClick={() => setIsModalOpen(true)}
+            whileHover={{ scale: 1.02, borderColor: 'rgba(113,113,122,0.5)' }}
+            whileTap={{ scale: 0.98 }}
+            className="rounded-xl border border-dashed border-border p-4 flex flex-col items-center justify-center gap-2 min-h-[140px] hover:bg-muted/30 transition-all cursor-pointer"
+          >
+            <div className="w-8 h-8 rounded-full border border-border flex items-center justify-center">
+              <Plus className="w-4 h-4 text-muted-foreground" />
+            </div>
+            <span className="text-xs font-medium text-muted-foreground">
+              {comparisonChains.length === 0 ? 'Select a chain' : `Add ${4 - comparisonChains.length === 1 ? 'last' : ''} chain`}
+            </span>
+          </motion.button>
+        )}
+      </div>
+
+      {/* Chart Section */}
       <AnimatePresence mode="wait">
         {hasMultipleChains ? (
           <motion.div
-            key="comparison-content"
+            key="chart-section"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
-            transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
-            className="space-y-6"
+            transition={{ duration: 0.35 }}
+            className="bg-card border border-border rounded-xl overflow-hidden"
           >
-            {/* Metrics Table */}
-            <motion.div
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: 0.1 }}
-            >
-              <ComparisonMetricsTable comparisonChains={comparisonChains} validatorCountBySubnet={validatorCountBySubnet} />
-            </motion.div>
-
-            {/* Controls: Metric Dropdown, Timeframe, Share */}
-            <motion.div
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: 0.2 }}
-              className="flex flex-col sm:flex-row items-center justify-center gap-4"
-            >
-              {/* Metric Selector Dropdown */}
-              <div className="relative" ref={metricDropdownRef}>
-                <motion.button
-                  onClick={() => setMetricDropdownOpen(!metricDropdownOpen)}
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  className="flex items-center gap-2 px-4 py-2 bg-muted rounded-lg border border-border text-sm font-medium text-foreground hover:bg-muted/70 transition-all min-w-[220px] justify-between"
-                >
-                  <span>{currentMetricConfig.name}</span>
-                  <motion.div
-                    animate={{ rotate: metricDropdownOpen ? 180 : 0 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <ChevronDown className="w-4 h-4 text-muted-foreground" />
-                  </motion.div>
-                </motion.button>
-
-                <AnimatePresence>
-                  {metricDropdownOpen && (
-                    <motion.div
-                      initial={{ opacity: 0, y: -8, scale: 0.96 }}
-                      animate={{ opacity: 1, y: 0, scale: 1 }}
-                      exit={{ opacity: 0, y: -8, scale: 0.96 }}
-                      transition={{ duration: 0.15, ease: [0.25, 0.1, 0.25, 1] }}
-                      className="absolute left-0 mt-2 w-full bg-card border border-border rounded-lg shadow-lg z-20 overflow-hidden"
-                    >
-                      {COMPARISON_METRICS.map((metric, i) => (
-                        <motion.button
-                          key={metric.id}
-                          initial={{ opacity: 0, x: -8 }}
-                          animate={{ opacity: 1, x: 0 }}
-                          transition={{ delay: i * 0.03 }}
-                          onClick={() => handleMetricChange(metric.id)}
-                          className={`w-full px-4 py-2.5 text-left text-sm transition-colors first:rounded-t-lg last:rounded-b-lg ${
-                            selectedMetric === metric.id
-                              ? 'bg-[#ef4444]/10 text-[#ef4444] font-medium'
-                              : 'text-foreground hover:bg-muted/30'
-                          }`}
-                        >
-                          {metric.name}
-                        </motion.button>
-                      ))}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-
-              {/* Timeframe Selector */}
-              <div className="inline-flex items-center gap-1 p-1 bg-muted rounded-lg border border-border">
-                {([7, 30] as const).map(days => (
-                  <motion.button
-                    key={days}
-                    onClick={() => handleTimeframeChange(days)}
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    className={`relative px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                      timeframe === days
-                        ? 'text-white'
-                        : 'text-muted-foreground hover:text-foreground'
+            {/* Chart Controls Bar */}
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-5 py-3 border-b border-border">
+              <div className="flex flex-wrap gap-1 p-1 bg-muted/50 rounded-lg">
+                {COMPARISON_METRICS.map(metric => (
+                  <button
+                    key={metric.id}
+                    onClick={() => handleMetricChange(metric.id)}
+                    className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
+                      selectedMetric === metric.id
+                        ? 'bg-[#ef4444] text-white shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted'
                     }`}
                   >
-                    {timeframe === days && (
-                      <motion.div
-                        layoutId="timeframe-pill"
-                        className="absolute inset-0 bg-[#ef4444] rounded-md"
-                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-                      />
-                    )}
-                    <span className="relative z-10">{days} Days</span>
-                  </motion.button>
+                    {metric.shortName}
+                  </button>
                 ))}
               </div>
+              <div className="flex items-center gap-2">
+                <div className="flex gap-1 p-1 bg-muted/50 rounded-lg">
+                  {([7, 30] as const).map(days => (
+                    <button
+                      key={days}
+                      onClick={() => handleTimeframeChange(days)}
+                      className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
+                        timeframe === days
+                          ? 'bg-secondary text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {days}D
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={handleCopyShareUrl}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+                >
+                  <Share2 className="w-3 h-3" />
+                  {copied ? 'Copied!' : 'Share'}
+                </button>
+              </div>
+            </div>
 
-              <motion.button
-                onClick={handleCopyShareUrl}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className="flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
-              >
-                <Share2 className="w-4 h-4" />
-                <AnimatePresence mode="wait">
-                  <motion.span
-                    key={copied ? 'copied' : 'share'}
-                    initial={{ opacity: 0, y: 4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -4 }}
-                    transition={{ duration: 0.15 }}
-                  >
-                    {copied ? 'Copied!' : 'Share'}
-                  </motion.span>
-                </AnimatePresence>
-              </motion.button>
-            </motion.div>
-
-            {/* Single Comparison Chart */}
-            <motion.div
-              key={selectedMetric}
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: 0.3 }}
-            >
+            {/* Chart */}
+            <div className="p-4">
               <ComparisonChart
                 comparisonChains={comparisonChains}
                 metricType={selectedMetric}
                 title={currentMetricConfig.name}
                 valueLabel={currentMetricConfig.valueLabel}
               />
-            </motion.div>
+            </div>
           </motion.div>
-        ) : (
-          <div
-            className="bg-card border border-border rounded-xl p-12 text-center"
+        ) : comparisonChains.length > 0 ? (
+          <motion.div
+            key="empty-state"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="bg-card border border-border rounded-xl p-10 text-center"
           >
-            <BarChart3 className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-foreground mb-2">
-              {comparisonChains.length === 0 ? 'Start Comparing Chains' : 'Add More Chains'}
-            </h3>
-            <p className="text-sm text-muted-foreground mb-6">
-              {comparisonChains.length === 0
-                ? 'Select at least 2 chains to compare their performance metrics side-by-side'
-                : 'Add at least one more chain to see the comparison'}
-            </p>
+            <p className="text-muted-foreground text-sm">Add at least one more chain to see the comparison chart</p>
             <motion.button
-              onClick={() => setIsModalOpen(!isModalOpen)}
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all ${
-                isModalOpen
-                  ? 'bg-[#dc2626] text-white'
-                  : 'bg-[#ef4444] text-white hover:bg-[#dc2626]'
-              }`}
+              onClick={() => setIsModalOpen(true)}
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.97 }}
+              className="mt-4 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#ef4444] text-white text-sm font-semibold hover:bg-[#dc2626] transition-all"
             >
-              {isModalOpen ? <X className="w-5 h-5" /> : <Plus className="w-5 h-5" />}
-              {isModalOpen ? 'Close' : comparisonChains.length === 0 ? 'Select Chains' : 'Add Another Chain'}
+              <Plus className="w-4 h-4" /> Add Another Chain
             </motion.button>
-          </div>
-        )}
+          </motion.div>
+        ) : null}
       </AnimatePresence>
 
       {/* Chain Selector Modal */}

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { getChains, getTPSHistory, getChainValidators, getL1BeatValidators, getL1BeatSubnetType, getL1BeatDailyFeeBurn, getL1BeatFeeMetrics, DailyFeeBurn } from '../api';
@@ -52,6 +52,8 @@ export function ChainDetails() {
     return params.has('compare') ? 'compare' : 'validators';
   });
   const [hoveredTab, setHoveredTab] = useState<string | null>(null);
+  const compareRef = useRef<HTMLDivElement>(null);
+  const hasScrolledToCompare = useRef(false);
   const [availableChains, setAvailableChains] = useState<Chain[]>([]);
   const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
   const [subnetType, setSubnetType] = useState<'l1' | 'legacy' | null>(null);
@@ -59,6 +61,21 @@ export function ChainDetails() {
   const [dailyFeeBurn, setDailyFeeBurn] = useState<DailyFeeBurn[]>([]);
   const [allTimeFeesBurned, setAllTimeFeesBurned] = useState<number>(0);
   const [feeBurnTimeframe, setFeeBurnTimeframe] = useState<0 | 7 | 30 | 90>(0);
+
+  // Auto-scroll to compare section when opened via shared URL
+  useEffect(() => {
+    if (hasScrolledToCompare.current || activeTab !== 'compare') return;
+    hasScrolledToCompare.current = true;
+    let attempts = 0;
+    const tryScroll = () => {
+      if (compareRef.current && attempts < 10) {
+        compareRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        attempts++;
+        setTimeout(tryScroll, 500);
+      }
+    };
+    setTimeout(tryScroll, 500);
+  }, [activeTab]);
 
   useEffect(() => {
     async function fetchData() {
@@ -705,12 +722,12 @@ export function ChainDetails() {
 
             <div className="space-y-4 sm:space-y-6">
               {/* Compare Tab */}
-              {activeTab === 'compare' && chain && (
+              {activeTab === 'compare' && chain && (<div ref={compareRef}>
                 <ComparisonView
                   currentChain={chain}
                   validatorCountBySubnet={validatorCountBySubnet}
                 />
-              )}
+              </div>)}
 
               {/* Economics Tab */}
               {activeTab === 'economics' && (

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -47,7 +47,10 @@ export function ChainDetails() {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const { theme } = useTheme();
   const [copied, setCopied] = useState<'chainId' | 'subnetId' | 'platformChainId' | null>(null);
-  const [activeTab, setActiveTab] = useState<'validators' | 'compare' | 'economics'>('validators');
+  const [activeTab, setActiveTab] = useState<'validators' | 'compare' | 'economics'>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.has('compare') ? 'compare' : 'validators';
+  });
   const [hoveredTab, setHoveredTab] = useState<string | null>(null);
   const [availableChains, setAvailableChains] = useState<Chain[]>([]);
   const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -88,8 +88,8 @@ export function ChainDetails() {
           };
 
           setChain(chainWithValidators);
-          // Store all chains for comparison feature
-          setAvailableChains(chains);
+          // Don't pass chains to comparison — let it fetch its own active-only list
+          setAvailableChains([]);
           // Use originalChainId if available for API calls that might require the numeric ID
           // Fallback to chainId if originalChainId is not present
           const apiChainId = foundChain.originalChainId || foundChain.chainId;
@@ -705,7 +705,6 @@ export function ChainDetails() {
               {activeTab === 'compare' && chain && (
                 <ComparisonView
                   currentChain={chain}
-                  availableChains={availableChains}
                   validatorCountBySubnet={validatorCountBySubnet}
                 />
               )}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
 import { ComparisonView } from '../components/comparison';
@@ -7,6 +8,9 @@ import { getChains, getL1BeatActiveValidatorCounts } from '../api';
 
 export function Metrics() {
   const [validatorCountBySubnet, setValidatorCountBySubnet] = useState<Record<string, number>>({});
+  const [searchParams] = useSearchParams();
+  const comparisonRef = useRef<HTMLDivElement>(null);
+  const hasScrolled = useRef(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -23,6 +27,17 @@ export function Metrics() {
     fetchData();
   }, []);
 
+  // Auto-scroll to comparison section when URL has compare params
+  useEffect(() => {
+    if (hasScrolled.current) return;
+    if (searchParams.has('compare') && comparisonRef.current) {
+      hasScrolled.current = true;
+      setTimeout(() => {
+        comparisonRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 300);
+    }
+  }, [searchParams]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
 
@@ -34,7 +49,7 @@ export function Metrics() {
         <ChainSpecificMetrics />
 
         {/* Chain Comparison */}
-        <section>
+        <section ref={comparisonRef}>
           <ComparisonView validatorCountBySubnet={validatorCountBySubnet} />
         </section>
       </main>

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -29,13 +29,18 @@ export function Metrics() {
 
   // Auto-scroll to comparison section when URL has compare params
   useEffect(() => {
-    if (hasScrolled.current) return;
-    if (searchParams.has('compare') && comparisonRef.current) {
-      hasScrolled.current = true;
-      setTimeout(() => {
-        comparisonRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }, 300);
-    }
+    if (hasScrolled.current || !searchParams.has('compare')) return;
+    hasScrolled.current = true;
+    // Retry scroll until the element is in the right position (content may still be loading)
+    let attempts = 0;
+    const tryScroll = () => {
+      if (comparisonRef.current && attempts < 10) {
+        comparisonRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        attempts++;
+        setTimeout(tryScroll, 500);
+      }
+    };
+    setTimeout(tryScroll, 500);
   }, [searchParams]);
 
   return (

--- a/src/pages/ValidatorDetails.tsx
+++ b/src/pages/ValidatorDetails.tsx
@@ -362,11 +362,40 @@ export function ValidatorDetails() {
               {isL1 ? (
                 <>
                   <DetailRow label="Total Deposited" value={`${formatAvax(totalDeposited)} AVAX`} />
-                  <DetailRow label="Fees Paid" value={`${formatAvax(feesPaid)} AVAX`} />
+                  <DetailRow label="Fees Paid" value={`${formatAvax(feesPaid)} AVAX`} valueColor="text-red-500" />
+                  <DetailRow label="Initial Deposit" value={`${formatAvax(initialDeposit)} AVAX`} />
+                  <DetailRow label="Total Top-ups" value={`${formatAvax(totalTopups)} AVAX`} valueColor="text-green-500" />
                   {refundAmount > 0 && (
                     <DetailRow label="Refund Amount" value={`${formatAvax(refundAmount)} AVAX`} />
                   )}
                   <DetailRow label="Weight" value={validator.weight.toLocaleString()} />
+
+                  {/* Balance Breakdown Bar */}
+                  {totalDeposited > 0 && (
+                    <div className="pt-3 mt-1">
+                      <p className="text-xs font-medium text-muted-foreground mb-2.5">Balance Breakdown</p>
+                      <div className="flex w-full h-2.5 rounded-full bg-muted overflow-hidden gap-0.5">
+                        <div
+                          className="h-full rounded-l-full bg-red-500 transition-all"
+                          style={{ width: `${(feesPaid / totalDeposited) * 100}%` }}
+                        />
+                        <div
+                          className="h-full rounded-r-full bg-green-500 transition-all"
+                          style={{ width: `${(balance / totalDeposited) * 100}%` }}
+                        />
+                      </div>
+                      <div className="flex items-center gap-4 mt-2">
+                        <div className="flex items-center gap-1.5">
+                          <div className="w-2 h-2 rounded-full bg-red-500" />
+                          <span className="text-[10px] text-muted-foreground">Fees Paid ({totalDeposited > 0 ? Math.round((feesPaid / totalDeposited) * 100) : 0}%)</span>
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          <span className="text-[10px] text-muted-foreground">Balance ({totalDeposited > 0 ? Math.round((balance / totalDeposited) * 100) : 0}%)</span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </>
               ) : (
                 <>


### PR DESCRIPTION
- Comparison: bento card layout with per-chain stats, color-coded borders, fees burned data, integrated metric tabs and timeframe toggle
- Comparison: filter to active mainnet chains only in chain selector
- Validator Details: add balance breakdown progress bar with fees/balance split
- Validator Details: add initial deposit and total top-ups rows with color coding
- ChainDetails: stop passing unfiltered chains to comparison view