### PR TITLE
feat: command palette, toasts, SEO, error boundaries, light-mode pass

### DIFF
--- a/src/components/AddToMetaMask.tsx
+++ b/src/components/AddToMetaMask.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { Wallet, Check, AlertCircle, ExternalLink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Chain } from '../types';
-import { isCoreInstalled, addNetworkToWallet } from '../utils/metamask';
+import { isCoreInstalled, addNetworkToWallet, switchToNetwork } from '../utils/metamask';
+import { useToast } from './Toaster';
 
 interface AddToMetaMaskProps {
   chain: Chain;
@@ -13,16 +14,19 @@ interface AddToMetaMaskProps {
 export function AddToMetaMask({ chain, variant = 'default', className = '' }: AddToMetaMaskProps) {
   const [status, setStatus] = useState<'idle' | 'adding' | 'success' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState<string>('');
-  
+  const { toast } = useToast();
+
   const handleAddToWallet = async () => {
     if (!isCoreInstalled()) {
       window.open('https://core.app/', '_blank', 'noopener,noreferrer');
+      toast('Install CORE wallet, then try again', 'info');
       return;
     }
 
     if (!chain.networkToken) {
       setStatus('error');
       setErrorMessage('Network token information is not available');
+      toast('Network token info is missing for this chain', 'error');
       setTimeout(() => setStatus('idle'), 3000);
       return;
     }
@@ -31,19 +35,30 @@ export function AddToMetaMask({ chain, variant = 'default', className = '' }: Ad
     setErrorMessage('');
 
     try {
-      console.log('Attempting to add network to wallet:', {
-        chainId: chain.chainId,
-        chainName: chain.chainName,
-        networkToken: chain.networkToken
-      });
-
       await addNetworkToWallet(chain);
       setStatus('success');
+      toast(`${chain.chainName} is ready in your wallet`, 'success');
+
+      // If the chain was already in the wallet, the add call is a silent no-op.
+      // Follow up with a switch so the wallet popup actually opens and the user
+      // gets visible feedback. Don't surface an error if this part fails — the
+      // network is already there either way.
+      const evmId = (typeof chain.evmChainId === 'number'
+        ? String(chain.evmChainId)
+        : chain.originalChainId) || '';
+      if (evmId) {
+        switchToNetwork(evmId).catch(() => {
+          // user rejected, already on chain, or some other minor wallet quirk
+        });
+      }
+
       setTimeout(() => setStatus('idle'), 3000);
     } catch (error) {
       console.error('Wallet add network error:', error);
+      const msg = error instanceof Error ? error.message : 'Failed to add network';
       setStatus('error');
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to add network');
+      setErrorMessage(msg);
+      toast(msg, 'error');
       setTimeout(() => setStatus('idle'), 5000);
     }
   };

--- a/src/components/SectionErrorBoundary.tsx
+++ b/src/components/SectionErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  label?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[SectionErrorBoundary]', this.props.label ?? 'section', error, info);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    const { label } = this.props;
+    return (
+      <div className="rounded-xl border border-border bg-card p-6 sm:p-8 flex flex-col items-center justify-center text-center">
+        <div className="w-10 h-10 rounded-full bg-[#ef4444]/12 flex items-center justify-center mb-3">
+          <AlertTriangle className="w-5 h-5 text-[#ef4444]" />
+        </div>
+        <h3 className="text-sm font-semibold text-foreground mb-1.5">
+          Couldn’t load {label ?? 'this section'}
+        </h3>
+        <p className="text-[12px] text-muted-foreground max-w-sm mb-4">
+          Something went wrong.
+        </p>
+        <button
+          type="button"
+          onClick={this.handleRetry}
+          className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-[12px] font-semibold bg-[#ef4444] text-white hover:bg-[#dc2626] transition-colors"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/components/TeleporterSankeyDiagram.tsx
+++ b/src/components/TeleporterSankeyDiagram.tsx
@@ -99,21 +99,20 @@ export function TeleporterSankeyDiagram() {
   const isVisibleRef = useRef(true);
   const activeParticlesRef = useRef<d3.Selection<SVGCircleElement, unknown, null, undefined>[]>([]);
   
-  // Force text colors to always be white for dark background
+  // Theme-aware text colors so labels remain legible against the card bg.
   const forceTextColors = useCallback(() => {
-    // Always use white text since we have a dark background
-    const textColor = '#ffffff';
-    const secondaryTextColor = 'rgba(255, 255, 255, 0.7)';
-    
-    // Force direct DOM updates to ensure color consistency
+    const isDark = theme === 'dark';
+    const textColor = isDark ? '#ffffff' : '#0f172a';
+    const secondaryTextColor = isDark ? 'rgba(255, 255, 255, 0.7)' : 'rgba(15, 23, 42, 0.65)';
+
     document.querySelectorAll('.node-label').forEach(el => {
-    (el as HTMLElement).style.setProperty('fill', textColor, 'important');
+      (el as HTMLElement).style.setProperty('fill', textColor, 'important');
     });
-    
+
     document.querySelectorAll('.value-label, .diagram-title').forEach(el => {
       (el as HTMLElement).style.setProperty('fill', secondaryTextColor, 'important');
     });
-  }, []);
+  }, [theme]);
   
   
   // Apply text colors when the diagram is first drawn or redrawn
@@ -569,7 +568,7 @@ export function TeleporterSankeyDiagram() {
         .attr('text-anchor', d => d.x0 < width / 2 ? 'start' : 'end')
         .attr('class', 'node-label')
         .text(d => d.displayName)
-        .attr('fill', '#ffffff')
+        .attr('fill', theme === 'dark' ? '#ffffff' : '#0f172a')
         .attr('font-weight', 'bold')
         .attr('font-size', '12px')
         .attr('pointer-events', 'none');
@@ -582,7 +581,7 @@ export function TeleporterSankeyDiagram() {
         .attr('class', 'value-label')
         .attr('text-anchor', d => d.x0 < width / 2 ? 'start' : 'end')
         .text(d => `${d.value.toLocaleString()} msgs`)
-        .attr('fill', 'rgba(255, 255, 255, 0.7)')
+        .attr('fill', theme === 'dark' ? 'rgba(255, 255, 255, 0.7)' : 'rgba(15, 23, 42, 0.65)')
         .attr('font-size', '10px')
         .attr('pointer-events', 'none')
         .attr('opacity', 0) // Hide by default
@@ -624,7 +623,7 @@ export function TeleporterSankeyDiagram() {
         .attr('fill', errorTextColor)
         .text('Error rendering diagram. Please try again.');
     }
-  }, [data, getChainColor, selectedChain, navigate, handleNodeClick]);
+  }, [data, getChainColor, selectedChain, navigate, handleNodeClick, theme]);
 
   // Handle window resize
   useEffect(() => {
@@ -763,7 +762,7 @@ export function TeleporterSankeyDiagram() {
       
       <div
         ref={containerRef}
-        className="relative bg-[#1c1c1e] h-[360px] sm:h-[520px] lg:h-[600px] overflow-hidden"
+        className="relative bg-card h-[360px] sm:h-[520px] lg:h-[600px] overflow-hidden"
       >
 
         {/* SVG for the Sankey diagram */}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,94 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CheckCircle2, AlertTriangle, Info, X } from 'lucide-react';
+
+type ToastVariant = 'success' | 'error' | 'info';
+
+interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  toast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const TOAST_DURATION = 2500;
+const MAX_TOASTS = 4;
+let nextId = 1;
+
+export function ToasterProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback((message: string, variant: ToastVariant = 'info') => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, variant }].slice(-MAX_TOASTS));
+    setTimeout(() => dismiss(id), TOAST_DURATION);
+  }, [dismiss]);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            aria-live="polite"
+            className="pointer-events-none fixed bottom-4 right-4 z-[80] flex flex-col items-end gap-2 max-w-[min(360px,calc(100vw-2rem))]"
+          >
+            {toasts.map((t) => (
+              <ToastItem key={t.id} toast={t} onDismiss={() => dismiss(t.id)} />
+            ))}
+          </div>,
+          document.body,
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const Icon = toast.variant === 'success' ? CheckCircle2 : toast.variant === 'error' ? AlertTriangle : Info;
+  const iconColor =
+    toast.variant === 'success'
+      ? 'text-green-500'
+      : toast.variant === 'error'
+        ? 'text-[#ef4444]'
+        : 'text-foreground';
+  return (
+    <div
+      role="status"
+      className="pointer-events-auto inline-flex items-start gap-2.5 min-h-9 px-3.5 py-2 rounded-xl bg-popover border border-border shadow-xl text-[12px] font-medium text-foreground"
+    >
+      <Icon className={`w-4 h-4 shrink-0 mt-0.5 ${iconColor}`} />
+      <span className="flex-1">{toast.message}</span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors mt-0.5"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (ctx) return ctx;
+  // Safe fallback so calls outside the provider don't crash; logs once per call.
+  return {
+    toast: (msg, variant) => {
+      // eslint-disable-next-line no-console
+      console.warn('[useToast] called outside ToasterProvider:', variant ?? 'info', msg);
+    },
+  };
+}
+
+export type { ToastVariant };

--- a/src/components/comparison/ComparisonView.tsx
+++ b/src/components/comparison/ComparisonView.tsx
@@ -557,7 +557,7 @@ export const ComparisonView = memo(function ComparisonView({
                           <TooltipContent
                             side="top"
                             align="end"
-                            className="max-w-[260px] bg-[#1c1c1e] border border-white/[0.08] text-foreground text-[11px] leading-relaxed px-3 py-2 shadow-xl shadow-black/40 [&>span]:hidden"
+                            className="max-w-[260px] bg-popover border border-border text-foreground text-[11px] leading-relaxed px-3 py-2 shadow-xl [&>span]:hidden"
                           >
                             This chain is a legacy subnet, not a converted L1. It doesn’t pay continuous validation fees to the P-Chain, so no fee burn is reported. Only chains converted via ACP-77 report this metric.
                           </TooltipContent>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -58,7 +58,7 @@ function MobileDock() {
   };
 
   return (
-    <nav className="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 px-2 py-2 rounded-2xl bg-[#1c1c1e]/90 dark:bg-[#1c1c1e]/95 backdrop-blur-xl border border-white/10 shadow-2xl">
+    <nav className="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 px-2 py-2 rounded-2xl bg-card/90 dark:bg-card/95 backdrop-blur-xl border border-border shadow-2xl">
       {dockItems.map(({ id, path, icon: Icon, label }) => {
         const active = isActive(path);
         return (

--- a/src/components/layout/SearchPalette.tsx
+++ b/src/components/layout/SearchPalette.tsx
@@ -1,20 +1,27 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight, BookOpen, Clock, FileText, Flame, Layers, LayoutGrid, Search, X } from 'lucide-react';
+import { ArrowRight, BookOpen, Clock, Command, Copy, FileText, Flame, Layers, LayoutGrid, Moon, Search, Sun, Trash2, X } from 'lucide-react';
 import { getChains } from '../../api';
 import type { Chain } from '../../types';
 import { acpService } from '../../services/acpService';
 import type { EnhancedACP } from '../../types';
 import { getBlogPosts, BlogPost } from '../../api/blogApi';
+import { useTheme } from '../../hooks/useTheme';
+import { useToast } from '../Toaster';
 
-type ResultType = 'page' | 'chain' | 'acp' | 'post';
+type ResultType = 'page' | 'chain' | 'acp' | 'post' | 'command';
 
 interface Result {
   id: string;
   type: ResultType;
   title: string;
   subtitle?: string;
-  to: string;
+  to?: string;
+  action?: () => void | Promise<void>;
+  keywords?: string;
+  icon?: typeof Command;
+  closeAfter?: boolean;
 }
 
 const RECENT_STORAGE_KEY = 'searchPalette:recents';
@@ -35,12 +42,29 @@ function loadRecents(): Result[] {
 }
 
 function saveRecent(result: Result) {
+  // Only persist navigable results, not one-off commands.
+  if (result.type === 'command' || !result.to) return;
   try {
     const current = loadRecents().filter(r => r.id !== result.id);
-    const next = [result, ...current].slice(0, RECENT_MAX);
+    const stripped: Result = {
+      id: result.id,
+      type: result.type,
+      title: result.title,
+      subtitle: result.subtitle,
+      to: result.to,
+    };
+    const next = [stripped, ...current].slice(0, RECENT_MAX);
     localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next));
   } catch {
     // localStorage may be full or unavailable; silent fail is fine here
+  }
+}
+
+function clearRecents() {
+  try {
+    localStorage.removeItem(RECENT_STORAGE_KEY);
+  } catch {
+    // silent fail
   }
 }
 
@@ -64,6 +88,7 @@ const TYPE_ICON: Record<ResultType, typeof LayoutGrid> = {
   chain: Layers,
   acp: FileText,
   post: BookOpen,
+  command: Command,
 };
 
 const TYPE_LABEL: Record<ResultType, string> = {
@@ -71,10 +96,13 @@ const TYPE_LABEL: Record<ResultType, string> = {
   chain: 'Chain',
   acp: 'ACP',
   post: 'Article',
+  command: 'Cmd',
 };
 
 export function SearchPalette({ open, onClose }: SearchPaletteProps) {
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
+  const { toast } = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
@@ -82,6 +110,51 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
   const [acps, setAcps] = useState<EnhancedACP[]>([]);
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [recents, setRecents] = useState<Result[]>([]);
+
+  const commands = useMemo<Result[]>(() => {
+    const isDark = theme === 'dark';
+    return [
+      {
+        id: 'cmd-theme',
+        type: 'command',
+        title: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+        subtitle: 'Toggle theme',
+        keywords: 'theme dark light mode toggle appearance',
+        icon: isDark ? Sun : Moon,
+        action: () => toggleTheme(),
+        closeAfter: true,
+      },
+      {
+        id: 'cmd-copy-url',
+        type: 'command',
+        title: 'Copy current URL',
+        subtitle: 'Share this page',
+        keywords: 'copy url link share clipboard',
+        icon: Copy,
+        action: async () => {
+          try {
+            await navigator.clipboard.writeText(window.location.href);
+            toast('URL copied to clipboard', 'success');
+          } catch {
+            toast('Failed to copy URL', 'error');
+          }
+        },
+      },
+      {
+        id: 'cmd-clear-recents',
+        type: 'command',
+        title: 'Clear recent searches',
+        subtitle: 'Wipe ⌘K history on this device',
+        keywords: 'clear recents history wipe reset',
+        icon: Trash2,
+        action: () => {
+          clearRecents();
+          setRecents([]);
+          toast('Recent searches cleared', 'success');
+        },
+      },
+    ];
+  }, [theme, toggleTheme]);
 
   useEffect(() => {
     if (!open) return;
@@ -164,18 +237,21 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
   const sections = useMemo<{ label: string; icon: typeof Clock; items: Result[] }[]>(() => {
     const q = query.trim().toLowerCase();
     if (q) {
-      const all = [...PAGES, ...chainResults, ...acpResults, ...postResults];
+      const all = [...commands, ...PAGES, ...chainResults, ...acpResults, ...postResults];
       const filtered = all
-        .filter((r) => `${r.title} ${r.subtitle ?? ''}`.toLowerCase().includes(q))
+        .filter((r) =>
+          `${r.title} ${r.subtitle ?? ''} ${r.keywords ?? ''}`.toLowerCase().includes(q),
+        )
         .slice(0, 30);
       return [{ label: 'Results', icon: Search, items: filtered }];
     }
     const out: { label: string; icon: typeof Clock; items: Result[] }[] = [];
+    out.push({ label: 'Commands', icon: Command, items: commands });
     if (recents.length > 0) out.push({ label: 'Recent', icon: Clock, items: recents });
     if (topChains.length > 0) out.push({ label: 'Top chains', icon: Flame, items: topChains });
     out.push({ label: 'Pages', icon: LayoutGrid, items: PAGES });
     return out;
-  }, [query, chainResults, acpResults, postResults, recents, topChains]);
+  }, [query, commands, chainResults, acpResults, postResults, recents, topChains]);
 
   const flatResults = useMemo<Result[]>(() => sections.flatMap((s) => s.items), [sections]);
 
@@ -183,10 +259,17 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
     setActive(0);
   }, [query]);
 
-  const handleSelect = (r: Result) => {
+  const handleSelect = async (r: Result) => {
+    if (r.type === 'command') {
+      await r.action?.();
+      if (r.closeAfter) onClose();
+      return;
+    }
     saveRecent(r);
-    navigate(r.to);
-    onClose();
+    if (r.to) {
+      navigate(r.to);
+      onClose();
+    }
   };
 
   useEffect(() => {
@@ -215,13 +298,13 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
 
   if (!open) return null;
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[12vh] px-4">
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-start justify-center pt-[12vh] px-4">
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/60 dark:bg-black/60 bg-black/40 backdrop-blur-sm"
         onClick={onClose}
       />
-      <div className="relative w-full max-w-xl rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-2xl shadow-black/60 overflow-hidden">
+      <div className="relative w-full max-w-xl rounded-2xl border border-border bg-popover shadow-2xl shadow-black/40 dark:shadow-black/60 overflow-hidden">
         <div className="flex items-center gap-3 px-4 h-12 border-b border-border">
           <Search className="w-4 h-4 text-muted-foreground shrink-0" />
           <input
@@ -265,7 +348,7 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
                     <ul>
                       {section.items.map((r) => {
                         const idx = cursor++;
-                        const Icon = TYPE_ICON[r.type];
+                        const Icon = r.icon ?? TYPE_ICON[r.type];
                         const isActive = idx === active;
                         return (
                           <li key={r.id}>
@@ -324,7 +407,8 @@ export function SearchPalette({ open, onClose }: SearchPaletteProps) {
           <span>{flatResults.length} results</span>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -3,6 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { HelmetProvider } from 'react-helmet-async';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { ToasterProvider } from './components/Toaster';
 import App from './App';
 
 export function render(url: string, context: any) {
@@ -13,7 +14,9 @@ export function render(url: string, context: any) {
       <ThemeProvider>
         <HelmetProvider context={helmetContext}>
           <StaticRouter location={url}>
-            <App />
+            <ToasterProvider>
+              <App />
+            </ToasterProvider>
           </StaticRouter>
         </HelmetProvider>
       </ThemeProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { ToasterProvider } from './components/Toaster';
 import App from './App.tsx';
 import './index.css';
 
@@ -18,8 +19,10 @@ const AppWrapper = () => (
     <StrictMode>
       <ThemeProvider>
         <HelmetProvider>
-        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-            <App />
+          <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+            <ToasterProvider>
+              <App />
+            </ToasterProvider>
           </BrowserRouter>
         </HelmetProvider>
       </ThemeProvider>

--- a/src/pages/ACPDetails.tsx
+++ b/src/pages/ACPDetails.tsx
@@ -9,6 +9,7 @@ import rehypeKatex from 'rehype-katex';
 import { useTheme } from '../hooks/useTheme';
 import 'katex/dist/katex.min.css';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
 import {
   ArrowLeft,
   ArrowUpCircle,
@@ -590,6 +591,11 @@ export default function ACPDetails() {
 
   return (
     <div className="bg-background text-foreground">
+      <SEO
+        title={`ACP-${acp.number} · ${acp.title}`}
+        description={`${acp.status ? `${acp.status} · ` : ''}${acp.track ? `${acp.track} track · ` : ''}Avalanche Community Proposal ${acp.number}.`}
+        url={`/acps/${acp.number}`}
+      />
       <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
           {/* Header */}
           <div className="flex items-center justify-between mb-5">

--- a/src/pages/ACPs.tsx
+++ b/src/pages/ACPs.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
 import {
   FileText,
   ExternalLink,
@@ -361,6 +362,11 @@ export default function ACPs() {
   }
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <SEO
+        title="Avalanche Community Proposals"
+        description="Browse, filter, and track every ACP — Avalanche Community Proposals — from draft through final, with status, track, and authors."
+        url="/acps"
+      />
       <div className="flex-1">
         <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}

--- a/src/pages/APIPlayground.tsx
+++ b/src/pages/APIPlayground.tsx
@@ -16,6 +16,7 @@ import { LandingState } from '../components/playground/LandingState';
 import { RequestPanel } from '../components/playground/RequestPanel';
 import { ResponsePanel } from '../components/playground/ResponsePanel';
 import { WebSocketPanel } from '../components/playground/WebSocketPanel';
+import { SEO } from '../components/SEO';
 import { HistoryBar, HistoryEntry } from '../components/playground/HistoryBar';
 import { BookmarkBar, Bookmark } from '../components/playground/BookmarkBar';
 import { useMediaQuery } from '../hooks/useMediaQuery';
@@ -621,6 +622,11 @@ export function APIPlayground() {
       ref={wrapperRef}
       className="flex flex-col bg-background text-foreground overflow-hidden"
     >
+      <SEO
+        title="API Playground"
+        description="Test the L1Beat REST and WebSocket APIs live — endpoint catalog, smart params, bookmarks, and history."
+        url="/api"
+      />
       {/* Mobile sidebar drawer */}
       <AnimatePresence>
         {isMobileSidebarOpen && (

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, RefreshCw, Search, X } from 'lucide-react';
 import { BlogPost, BlogTag, getBlogPosts, getBlogTags } from '../api/blogApi';
 import { BlogCard } from '../components/BlogCard';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
 
 const POSTS_PER_PAGE = 12;
 
@@ -110,6 +111,11 @@ export function BlogList() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title="Blog"
+        description="Insights, research, and deep-dives on Avalanche L1s — performance, economics, and the people building them."
+        url="/blog"
+      />
       <Hero
         totalArticles={posts.length}
         latestUpdate={latestUpdate}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -290,7 +290,7 @@ export function BlogPost() {
 
       <div className="lg:flex lg:gap-10 lg:items-start">
         <article className="flex-1 min-w-0 space-y-6">
-          <div className="relative overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-xl shadow-black/40">
+          <div className="relative overflow-hidden rounded-2xl border border-border bg-card shadow-xl">
             <div aria-hidden className="pointer-events-none absolute inset-0">
               <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-[#ef4444]/15 blur-3xl" />
             </div>
@@ -338,7 +338,7 @@ export function BlogPost() {
             />
           )}
 
-          <div className="bg-[#1c1c1e] rounded-2xl border border-white/[0.08] p-6 sm:p-7 shadow-xl shadow-black/40">
+          <div className="bg-card rounded-2xl border border-border p-6 sm:p-7 shadow-xl">
             <div ref={contentRef} className="prose-content max-w-none">
               {renderMainContent(post.mainContent || post.content)}
             </div>

--- a/src/pages/BrandGuidelines.tsx
+++ b/src/pages/BrandGuidelines.tsx
@@ -8,6 +8,7 @@ import { UsageGuidelines } from '../components/branding/UsageGuidelines';
 import { DownloadAssets } from '../components/branding/DownloadAssets';
 import { ExampleApplications } from '../components/branding/ExampleApplications';
 import { useTheme } from '../hooks/useTheme';
+import { SEO } from '../components/SEO';
 
 const SECTIONS = [
   { id: 'overview', label: 'Overview', icon: LayoutIcon },
@@ -27,6 +28,11 @@ export function BrandGuidelines() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title="Brand Guidelines"
+        description="L1Beat brand kit — logo, colors, typography, usage rules, and downloadable assets."
+        url="/brand"
+      />
       <header>
         <div className="text-[11px] font-bold tracking-[0.15em] text-[#ef4444] mb-1.5">
           BRAND GUIDELINES
@@ -65,7 +71,7 @@ export function BrandGuidelines() {
 
       {activeSection === 'overview' && (
         <div className="space-y-6">
-          <section className="relative overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-xl shadow-black/40">
+          <section className="relative overflow-hidden rounded-2xl border border-border bg-card shadow-xl">
             <div aria-hidden className="pointer-events-none absolute inset-0">
               <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-[#ef4444]/15 blur-3xl" />
             </div>

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -28,6 +28,9 @@ import { StakeDistributionChart, getValidatorColor } from '../components/StakeDi
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, ChartTooltip);
 import { AddToMetaMask } from '../components/AddToMetaMask';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
+import { SectionErrorBoundary } from '../components/SectionErrorBoundary';
+import { useToast } from '../components/Toaster';
 import { useTheme } from '../hooks/useTheme';
 import { formatUnits, parseBaseUnits, unitsToNumber } from '../utils/formatUnits';
 import { ComparisonView } from '../components/comparison/ComparisonView';
@@ -35,6 +38,7 @@ import { ComparisonView } from '../components/comparison/ComparisonView';
 export function ChainDetails() {
   const { chainId } = useParams();
   const navigate = useNavigate();
+  const { toast } = useToast();
   const [chain, setChain] = useState<Chain | null>(null);
   const [tpsHistory, setTPSHistory] = useState<TPSHistory[]>([]);
   const [loading, setLoading] = useState(true);
@@ -149,14 +153,14 @@ export function ChainDetails() {
   }, [dailyFeeBurn, feeBurnTimeframe]);
 
   const handleCopy = async (type: 'chainId' | 'subnetId' | 'platformChainId', value?: string) => {
-    if (value) {
-      try {
-        await navigator.clipboard.writeText(value);
-        setCopied(type);
-        setTimeout(() => setCopied(null), 2000);
-      } catch (err) {
-        console.error('Failed to copy:', err);
-      }
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(type);
+      setTimeout(() => setCopied(null), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      toast('Failed to copy to clipboard', 'error');
     }
   };
 
@@ -346,6 +350,15 @@ export function ChainDetails() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title={chain.chainName}
+        description={
+          chain.description?.slice(0, 200) ||
+          `${chain.chainName} on Avalanche — current TPS, validators, economics, and a side-by-side compare against other L1s.`
+        }
+        image={chain.chainLogoUri}
+        url={`/chain/${chain.chainId}`}
+      />
       <button
         onClick={() => navigate('/')}
         className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
@@ -354,7 +367,7 @@ export function ChainDetails() {
         All chains
       </button>
 
-      <header className="relative overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-xl shadow-black/40">
+      <header className="relative overflow-hidden rounded-2xl border border-border bg-card shadow-xl">
         <div aria-hidden className="pointer-events-none absolute inset-0">
           <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-[#ef4444]/15 blur-3xl" />
         </div>
@@ -452,7 +465,14 @@ export function ChainDetails() {
                     <>
                       <span>·</span>
                       <button
-                        onClick={() => navigator.clipboard.writeText(chain.rpcUrls?.[0] || '')}
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(chain.rpcUrls?.[0] || '');
+                            toast('RPC URL copied', 'success');
+                          } catch {
+                            toast('Failed to copy RPC URL', 'error');
+                          }
+                        }}
                         className="inline-flex items-center gap-1 h-5 px-1.5 rounded bg-background/40 hover:bg-background/70 transition-colors"
                         title={chain.rpcUrls[0]}
                       >
@@ -487,7 +507,7 @@ export function ChainDetails() {
                   href={chain.website}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-white/[0.08] bg-background/40 hover:bg-background/70 transition-colors"
+                  className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-border bg-background/40 hover:bg-background/70 transition-colors"
                   title="Website"
                 >
                   <Globe className="w-3.5 h-3.5 text-muted-foreground" />
@@ -498,7 +518,7 @@ export function ChainDetails() {
                   href={chain.explorerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-white/[0.08] bg-background/40 hover:bg-background/70 transition-colors"
+                  className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-border bg-background/40 hover:bg-background/70 transition-colors"
                   title="Explorer"
                 >
                   <ExternalLink className="w-3.5 h-3.5 text-muted-foreground" />
@@ -512,7 +532,7 @@ export function ChainDetails() {
                     href={social.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-white/[0.08] bg-background/40 hover:bg-background/70 transition-colors"
+                    className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-border bg-background/40 hover:bg-background/70 transition-colors"
                     title={social.name}
                   >
                     <Icon className="w-3.5 h-3.5 text-muted-foreground" />
@@ -607,14 +627,18 @@ export function ChainDetails() {
             <div className="space-y-4 sm:space-y-6">
               {/* Compare Tab */}
               {activeTab === 'compare' && chain && (<div ref={compareRef}>
-                <ComparisonView
-                  currentChain={chain}
-                  validatorCountBySubnet={validatorCountBySubnet}
-                />
+                <SectionErrorBoundary label="chain comparison">
+                  <ComparisonView
+                    currentChain={chain}
+                    validatorCountBySubnet={validatorCountBySubnet}
+                  />
+                </SectionErrorBoundary>
               </div>)}
 
               {/* Economics Tab */}
-              {activeTab === 'economics' && (() => {
+              {activeTab === 'economics' && (
+                <SectionErrorBoundary label="economics">
+                  {(() => {
                 const evmId = (chain.originalChainId || '').toString();
                 const lcName = (chain.chainName || '').toLowerCase();
                 const isPrimaryNetwork = lcName.includes('c-chain') || evmId === '43114';
@@ -906,9 +930,12 @@ export function ChainDetails() {
                 </div>
                 );
               })()}
+                </SectionErrorBoundary>
+              )}
 
               {/* Validators Tab */}
               {activeTab === 'validators' && (
+                <SectionErrorBoundary label="validators">
                 <div className="space-y-4 sm:space-y-6">
                   {/* No active validators warning */}
                   {chain.validators.length > 0 && !chain.validators.some(v => v.active) && (
@@ -1229,6 +1256,7 @@ export function ChainDetails() {
                     )}
                   </div>
                 </div>
+                </SectionErrorBoundary>
               )}
             </div>
     </div>
@@ -1342,21 +1370,21 @@ function ValidatorPagination({
 function ChainDetailsSkeleton() {
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
-      <div className="h-4 w-24 rounded bg-white/[0.04] animate-pulse" />
+      <div className="h-4 w-24 rounded bg-muted animate-pulse" />
 
       {/* Header card */}
-      <div className="rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-xl shadow-black/40 p-6 sm:p-7">
+      <div className="rounded-2xl border border-border bg-card shadow-xl p-6 sm:p-7">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-4">
-            <div className="w-14 h-14 rounded-2xl bg-white/[0.04] animate-pulse" />
+            <div className="w-14 h-14 rounded-2xl bg-muted animate-pulse" />
             <div className="space-y-2.5">
               <div className="flex items-center gap-2">
-                <div className="h-7 w-48 rounded bg-white/[0.04] animate-pulse" />
-                <div className="h-5 w-16 rounded-full bg-white/[0.04] animate-pulse" />
-                <div className="h-5 w-14 rounded-full bg-white/[0.04] animate-pulse" />
+                <div className="h-7 w-48 rounded bg-muted animate-pulse" />
+                <div className="h-5 w-16 rounded-full bg-muted animate-pulse" />
+                <div className="h-5 w-14 rounded-full bg-muted animate-pulse" />
               </div>
-              <div className="h-3 w-64 rounded bg-white/[0.04] animate-pulse" />
-              <div className="h-3 w-80 max-w-full rounded bg-white/[0.04] animate-pulse" />
+              <div className="h-3 w-64 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-80 max-w-full rounded bg-muted animate-pulse" />
             </div>
           </div>
         </div>
@@ -1366,7 +1394,7 @@ function ChainDetailsSkeleton() {
       <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 py-2 border-b border-border">
         <div className="flex items-center gap-1">
           {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="h-8 w-24 rounded-lg bg-white/[0.04] animate-pulse" />
+            <div key={i} className="h-8 w-24 rounded-lg bg-muted animate-pulse" />
           ))}
         </div>
       </div>
@@ -1376,10 +1404,10 @@ function ChainDetailsSkeleton() {
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="rounded-xl border border-border bg-card p-4 sm:p-5 space-y-3">
             <div className="flex items-center justify-between">
-              <div className="h-3 w-20 rounded bg-white/[0.04] animate-pulse" />
-              <div className="w-7 h-7 rounded-lg bg-white/[0.04] animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+              <div className="w-7 h-7 rounded-lg bg-muted animate-pulse" />
             </div>
-            <div className="h-7 w-24 rounded bg-white/[0.04] animate-pulse" />
+            <div className="h-7 w-24 rounded bg-muted animate-pulse" />
           </div>
         ))}
       </div>
@@ -1387,24 +1415,24 @@ function ChainDetailsSkeleton() {
       {/* Content body — generic validator table placeholder */}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="px-4 sm:px-6 py-4 border-b border-border flex items-center justify-between">
-          <div className="h-5 w-40 rounded bg-white/[0.04] animate-pulse" />
-          <div className="h-9 w-64 rounded-lg bg-white/[0.04] animate-pulse" />
+          <div className="h-5 w-40 rounded bg-muted animate-pulse" />
+          <div className="h-9 w-64 rounded-lg bg-muted animate-pulse" />
         </div>
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
             className="flex items-center gap-4 px-4 sm:px-6 py-4 border-b border-border/60 last:border-b-0"
           >
-            <div className="h-5 w-16 rounded-full bg-white/[0.04] animate-pulse" />
+            <div className="h-5 w-16 rounded-full bg-muted animate-pulse" />
             <div className="flex items-center gap-3 flex-1">
-              <div className="w-9 h-9 rounded-lg bg-white/[0.04] animate-pulse" />
+              <div className="w-9 h-9 rounded-lg bg-muted animate-pulse" />
               <div className="space-y-1.5">
-                <div className="h-3 w-40 rounded bg-white/[0.04] animate-pulse" />
-                <div className="h-2.5 w-24 rounded bg-white/[0.04] animate-pulse" />
+                <div className="h-3 w-40 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
               </div>
             </div>
-            <div className="h-3 w-20 rounded bg-white/[0.04] animate-pulse" />
-            <div className="h-3 w-24 rounded bg-white/[0.04] animate-pulse" />
+            <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-24 rounded bg-muted animate-pulse" />
           </div>
         ))}
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
+import { SEO } from '../components/SEO';
 import {
   Activity,
   ChevronRight,
@@ -452,6 +453,11 @@ export function Dashboard() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title="Overview"
+        description="Live screener for every Avalanche L1 — current TPS, validators, network share, 7-day trend, and a watchlist you can compare."
+        url="/"
+      />
       <Hero range={range} onRangeChange={setRange} />
       <KpiCards metrics={metrics} activeChains={activeCount} range={range} />
 
@@ -528,7 +534,7 @@ export function Dashboard() {
       />
 
       {selected.size > 0 && (
-        <div className="hidden md:flex fixed bottom-6 left-1/2 -translate-x-1/2 z-40 items-center gap-2 px-2.5 py-2 rounded-xl border border-white/[0.08] bg-[#1c1c1e] shadow-2xl shadow-black/60">
+        <div className="hidden md:flex fixed bottom-6 left-1/2 -translate-x-1/2 z-40 items-center gap-2 px-2.5 py-2 rounded-xl border border-border bg-card shadow-2xl">
           <span className="text-[12px] text-muted-foreground pl-1.5">
             <span className="text-foreground font-semibold">{selected.size}</span> selected
             {selected.size >= MAX_COMPARE && (
@@ -1271,9 +1277,9 @@ function DashboardSkeleton() {
       {/* Hero */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-2.5">
-          <div className="h-3 w-24 rounded bg-white/[0.04] animate-pulse" />
-          <div className="h-8 w-64 rounded bg-white/[0.04] animate-pulse" />
-          <div className="h-4 w-80 rounded bg-white/[0.04] animate-pulse" />
+          <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+          <div className="h-8 w-64 rounded bg-muted animate-pulse" />
+          <div className="h-4 w-80 rounded bg-muted animate-pulse" />
         </div>
         <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-card border border-border h-9 w-44 animate-pulse" />
       </div>
@@ -1283,11 +1289,11 @@ function DashboardSkeleton() {
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="rounded-xl border border-border bg-card p-4 sm:p-5 space-y-3">
             <div className="flex items-center justify-between">
-              <div className="h-3 w-20 rounded bg-white/[0.04] animate-pulse" />
-              <div className="w-7 h-7 rounded-lg bg-white/[0.04] animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+              <div className="w-7 h-7 rounded-lg bg-muted animate-pulse" />
             </div>
-            <div className="h-8 w-24 rounded bg-white/[0.04] animate-pulse" />
-            <div className="h-3 w-32 rounded bg-white/[0.04] animate-pulse" />
+            <div className="h-8 w-24 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-32 rounded bg-muted animate-pulse" />
           </div>
         ))}
       </div>
@@ -1296,13 +1302,13 @@ function DashboardSkeleton() {
       <section className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="flex items-center gap-3 px-4 sm:px-5 py-3 border-b border-border">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-7 w-24 rounded-md bg-white/[0.04] animate-pulse" />
+            <div key={i} className="h-7 w-24 rounded-md bg-muted animate-pulse" />
           ))}
         </div>
         <div className="flex items-center gap-3 px-4 sm:px-5 py-3 border-b border-border">
-          <div className="flex-1 h-9 rounded-lg bg-white/[0.04] animate-pulse" />
+          <div className="flex-1 h-9 rounded-lg bg-muted animate-pulse" />
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-7 w-16 rounded-full bg-white/[0.04] animate-pulse" />
+            <div key={i} className="h-7 w-16 rounded-full bg-muted animate-pulse" />
           ))}
         </div>
         <div className="px-2 sm:px-0">
@@ -1311,22 +1317,22 @@ function DashboardSkeleton() {
               key={i}
               className="flex items-center gap-4 px-3 sm:px-5 py-3 border-b border-border/60 last:border-b-0"
             >
-              <div className="w-4 h-4 rounded bg-white/[0.04] animate-pulse" />
-              <div className="w-4 h-4 rounded bg-white/[0.04] animate-pulse" />
+              <div className="w-4 h-4 rounded bg-muted animate-pulse" />
+              <div className="w-4 h-4 rounded bg-muted animate-pulse" />
               <div className="flex items-center gap-3 flex-1">
-                <div className="w-8 h-8 rounded-full bg-white/[0.04] animate-pulse" />
+                <div className="w-8 h-8 rounded-full bg-muted animate-pulse" />
                 <div className="space-y-1.5">
-                  <div className="h-3 w-24 rounded bg-white/[0.04] animate-pulse" />
-                  <div className="h-2.5 w-16 rounded bg-white/[0.04] animate-pulse" />
+                  <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+                  <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
                 </div>
               </div>
-              <div className="h-3 w-12 rounded bg-white/[0.04] animate-pulse" />
-              <div className="hidden md:block h-3 w-12 rounded bg-white/[0.04] animate-pulse" />
-              <div className="hidden lg:block h-3 w-12 rounded bg-white/[0.04] animate-pulse" />
-              <div className="hidden sm:block h-6 w-20 rounded bg-white/[0.04] animate-pulse" />
-              <div className="h-3 w-12 rounded bg-white/[0.04] animate-pulse" />
-              <div className="hidden lg:block h-5 w-16 rounded-full bg-white/[0.04] animate-pulse" />
-              <div className="h-5 w-16 rounded-full bg-white/[0.04] animate-pulse" />
+              <div className="h-3 w-12 rounded bg-muted animate-pulse" />
+              <div className="hidden md:block h-3 w-12 rounded bg-muted animate-pulse" />
+              <div className="hidden lg:block h-3 w-12 rounded bg-muted animate-pulse" />
+              <div className="hidden sm:block h-6 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-12 rounded bg-muted animate-pulse" />
+              <div className="hidden lg:block h-5 w-16 rounded-full bg-muted animate-pulse" />
+              <div className="h-5 w-16 rounded-full bg-muted animate-pulse" />
             </div>
           ))}
         </div>

--- a/src/pages/Flows.tsx
+++ b/src/pages/Flows.tsx
@@ -4,6 +4,8 @@ import { getChains, getTeleporterMessages } from '../api';
 import type { TeleporterMessageData } from '../types';
 import { TeleporterSankeyDiagram } from '../components/TeleporterSankeyDiagram';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
+import { SectionErrorBoundary } from '../components/SectionErrorBoundary';
 
 interface Corridor {
   source: string;
@@ -136,6 +138,11 @@ export function Flows() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title="Cross-chain Flows"
+        description="ICM and Teleporter activity across Avalanche L1s — sender/receiver Sankey, top corridors, and live message volume."
+        url="/flows"
+      />
       <header>
         <div className="text-[11px] font-bold tracking-[0.15em] text-[#ef4444] mb-1.5">
           INTERCHAIN MESSAGING
@@ -152,15 +159,19 @@ export function Flows() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6 lg:items-stretch">
         <div className="lg:col-span-2 min-w-0">
-          <TeleporterSankeyDiagram />
+          <SectionErrorBoundary label="the Sankey diagram">
+            <TeleporterSankeyDiagram />
+          </SectionErrorBoundary>
         </div>
-        <CorridorRail
-          corridors={allCorridors}
-          totalCount={stats.total}
-          totalCorridors={stats.corridors}
-          logoByChain={logoByChain}
-          loading={loading}
-        />
+        <SectionErrorBoundary label="top corridors">
+          <CorridorRail
+            corridors={allCorridors}
+            totalCount={stats.total}
+            totalCorridors={stats.corridors}
+            logoByChain={logoByChain}
+            loading={loading}
+          />
+        </SectionErrorBoundary>
       </div>
     </div>
   );

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Activity, ArrowDownRight, ArrowUpRight, GitCompareArrows, Info, TrendingUp, Users, Zap } from 'lucide-react';
+import { SEO } from '../components/SEO';
+import { SectionErrorBoundary } from '../components/SectionErrorBoundary';
 import { AvalancheNetworkMetrics } from '../components/AvalancheNetworkMetrics';
 import { ChainSpecificMetrics } from '../components/ChainSpecificMetrics';
 import { ComparisonView } from '../components/comparison';
@@ -267,6 +269,11 @@ export function Metrics() {
 
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title="Network Metrics"
+        description="Aggregate Avalanche L1 metrics — cross-chain TPS, transactions, validators, gas, fees, and a side-by-side compare tool."
+        url="/metrics"
+      />
       <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="text-[11px] font-bold tracking-[0.15em] text-[#ef4444] mb-1.5">
@@ -320,13 +327,19 @@ export function Metrics() {
       </section>
 
       <section id="network" className="scroll-mt-28">
-        <AvalancheNetworkMetrics />
+        <SectionErrorBoundary label="Network charts">
+          <AvalancheNetworkMetrics />
+        </SectionErrorBoundary>
       </section>
       <section id="chains" className="scroll-mt-28">
-        <ChainSpecificMetrics />
+        <SectionErrorBoundary label="chain metrics">
+          <ChainSpecificMetrics />
+        </SectionErrorBoundary>
       </section>
       <section id="compare" ref={comparisonRef} className="scroll-mt-28">
-        <ComparisonView validatorCountBySubnet={validatorCountBySubnet} />
+        <SectionErrorBoundary label="chain comparison">
+          <ComparisonView validatorCountBySubnet={validatorCountBySubnet} />
+        </SectionErrorBoundary>
       </section>
 
       <button
@@ -382,7 +395,7 @@ function KpiStrip({ kpis, range }: { kpis: Kpi[] | null; range: Range }) {
                     <TooltipContent
                       side="top"
                       align="start"
-                      className="max-w-[240px] bg-[#1c1c1e] border border-white/[0.08] text-foreground text-[11px] leading-relaxed px-3 py-2 shadow-xl shadow-black/40 [&>span]:hidden"
+                      className="max-w-[240px] bg-popover border border-border text-foreground text-[11px] leading-relaxed px-3 py-2 shadow-xl [&>span]:hidden"
                     >
                       {tooltip}
                     </TooltipContent>

--- a/src/pages/ValidatorDetails.tsx
+++ b/src/pages/ValidatorDetails.tsx
@@ -7,6 +7,8 @@ import { getL1BeatValidator, getL1BeatValidatorDeposits, getChainBySubnetId, get
 import type { L1BeatValidator } from '../api';
 import type { Chain, ValidatorDeposit } from '../types';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { SEO } from '../components/SEO';
+import { useToast } from '../components/Toaster';
 import { useTheme } from '../hooks/useTheme';
 
 const PRIMARY_NETWORK_SUBNET_ID = '11111111111111111111111111111111LpoYY';
@@ -50,6 +52,7 @@ export function ValidatorDetails() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { theme: _ } = useTheme();
+  const { toast } = useToast();
 
   const subnetId = searchParams.get('subnet') || undefined;
 
@@ -98,10 +101,14 @@ export function ValidatorDetails() {
     });
   }, [validatorId, subnetId]);
 
-  const copyToClipboard = (text: string, type: 'node' | 'validation' | 'bls' | 'owner' | 'tx') => {
-    navigator.clipboard.writeText(text);
-    setCopied(type);
-    setTimeout(() => setCopied(null), 2000);
+  const copyToClipboard = async (text: string, type: 'node' | 'validation' | 'bls' | 'owner' | 'tx') => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(type);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      toast('Failed to copy to clipboard', 'error');
+    }
   };
 
   if (loading) {
@@ -177,8 +184,14 @@ export function ValidatorDetails() {
     legacy: { label: 'Legacy Subnet', badgeBg: 'bg-orange-100 dark:bg-orange-900/40', badgeText: 'text-orange-700 dark:text-orange-300' },
   }[kind];
 
+  const nodeShort = `${validator.node_id.slice(0, 10)}…${validator.node_id.slice(-6)}`;
   return (
     <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <SEO
+        title={`${nodeShort} · Validator`}
+        description={`${chain ? `${chain.chainName} validator ` : 'Avalanche validator '}${nodeShort} — balance, uptime, deposit history, and validation record.`}
+        url={`/validator/${validator.node_id}`}
+      />
       <button
         onClick={() => (chain ? navigate(`/chain/${chain.chainId}`) : navigate(-1))}
         className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
@@ -187,7 +200,7 @@ export function ValidatorDetails() {
         {backLabel}
       </button>
 
-      <header className="relative overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1c1c1e] shadow-xl shadow-black/40">
+      <header className="relative overflow-hidden rounded-2xl border border-border bg-card shadow-xl">
         <div aria-hidden className="pointer-events-none absolute inset-0">
           <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-[#ef4444]/15 blur-3xl" />
         </div>
@@ -263,7 +276,7 @@ export function ValidatorDetails() {
               href={`https://subnets.avax.network/validators/${validator.node_id}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg border border-white/[0.08] bg-background/40 hover:bg-background/70 transition-colors text-xs font-medium text-muted-foreground shrink-0 self-start"
+              className="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg border border-border bg-background/40 hover:bg-background/70 transition-colors text-xs font-medium text-muted-foreground shrink-0 self-start"
             >
               Explorer <ExternalLink className="w-3 h-3" />
             </a>


### PR DESCRIPTION
⌘K palette becomes a real command palette with three built-in actions (toggle theme, copy current URL, clear recent searches), keyword search across commands, an empty-state view that groups Commands / Recent / Top Chains / Pages, and a portal mount so the dim overlay sits above the TopBar instead of leaking through its backdrop-blur. Active chains filtered to mainnet with TPS ≥ 0.05 so the Top Chains list isn't junk.

Global toast system: ToasterProvider at app root, useToast() hook, success / error / info variants stacked bottom-right with auto-dismiss. Wired into ChainDetails copy buttons (subnetId, RPC), ValidatorDetails copy actions, palette URL/clear, and the Add to Wallet flow.

Add to Wallet: chains the wallet's switch call after a successful add so the wallet popup actually opens when the network was already there (addEthereumChain silently no-ops in that case). Plus toast confirmation on success, error toast on every failure path.

Section error boundaries: SectionErrorBoundary component wraps the heavy data sections on Metrics (network charts, chain-specific, compare), ChainDetails tabs (compare, economics, validators), and Flows (Sankey, corridor rail). One section crashing shows a small fallback card with a Retry button; the rest of the page stays usable.

SEO/metadata via the existing react-helmet-async setup: per-page <SEO />
on Overview, Metrics, Flows, ACPs (list + detail with dynamic title), ChainDetails (uses chain logo as OG image), ValidatorDetails, API Playground, Blog list, Brand Guidelines.

Light-mode polish: every hardcoded bg-[#1c1c1e] / border-white/[0.08] / shadow-black/40 swapped for theme-aware tokens (bg-card, bg-popover, border-border). Skeleton placeholders moved from bg-white/[0.04] to bg-muted so they're visible in light mode. TeleporterSankeyDiagram text fills become theme-conditional and the chart redraws on theme change.