### PR TITLE
fix(footer): remove duplicate footer on ACPs and 404 pages

### DIFF
--- a/src/pages/ACPs.tsx
+++ b/src/pages/ACPs.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
-import { Footer } from '../components/Footer';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { SEO } from '../components/SEO';
 import {
@@ -807,9 +806,6 @@ export default function ACPs() {
           )}
         </div>
       </div>
-
-      {/* Footer */}
-      <Footer />
     </div>
   );
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FileQuestion, ArrowLeft } from 'lucide-react';
 import { ThemeToggle } from '../components/ThemeToggle';
-import { Footer } from '../components/Footer';
 
 export function NotFound() {
   const navigate = useNavigate();
@@ -34,8 +33,6 @@ export function NotFound() {
           </button>
         </div>
       </div>
-
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Both pages render inside <Layout>, which already renders <Footer />, but each also rendered its own — showing two footers. Drop the in-page Footer (and its now-unused import) from ACPs and NotFound.