### PR TITLE
feat(api): launch public API playground and restore typecheck gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 .vscode/*
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && node scripts/ssg.js",
-    "build:spa": "tsc && vite build",
+    "build": "tsc -b && node scripts/ssg.js",
+    "build:spa": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "build-acps": "node scripts/build-acps.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1749,8 +1749,12 @@ export async function getL1BeatValidators(subnetId: string, activeOnly: boolean 
         const isStaked = v.staked_amount != null;
         return {
           address: v.node_id,
-          active: v.active === true || (v.active as unknown) === 'true' || v.active === 1,
-          uptime: v.primary_uptime ?? v.uptime_percentage,
+          // API may return active as a boolean, the string 'true', or the number 1.
+          // Compare via `unknown` so the defensive string/number checks are allowed.
+          active: v.active === true || (v.active as unknown) === 'true' || (v.active as unknown) === 1,
+          // The API always supplies one of these; consumers treat uptime as a
+          // number, so assert it here rather than widening the domain type.
+          uptime: (v.primary_uptime ?? v.uptime_percentage) as number,
           weight: String(v.weight),
           stakeUnit: (isStaked ? 'tokens' : 'weight') as 'tokens' | 'weight',
           stakedAmount: isStaked ? String(v.staked_amount) : undefined,
@@ -1916,7 +1920,8 @@ export async function getNetworkDailyFeeBurn(days: number = 30): Promise<{ times
       // Get all L1 chains to find subnet IDs
       const chains = await getChains();
       const l1SubnetIds = [...new Set(
-        chains.filter(c => c.isL1 && c.subnetId).map(c => c.subnetId)
+        // Filter guarantees subnetId is present, so it is safe as a string here.
+        chains.filter(c => c.isL1 && c.subnetId).map(c => c.subnetId!)
       )];
 
       // Fetch daily fees for all subnets in parallel

--- a/src/components/ACPCard.tsx
+++ b/src/components/ACPCard.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { motion } from 'framer-motion';
-import { acpService } from '../services/acpService';
 import {
   Users,
   ArrowRight,
   BookOpen,
-  MessageCircle,
+  type LucideIcon,
 } from 'lucide-react';
+import type { EnhancedACP } from '../types';
 
-const EnhancedACPCard = ({ acp, viewMode = 'grid', onClick }) => {
-  
-  const getStatusColor = (status) => {
+interface EnhancedACPCardProps {
+  acp: EnhancedACP;
+  viewMode?: 'grid' | 'list';
+  onClick: (acp: EnhancedACP) => void;
+}
+
+const EnhancedACPCard = ({ acp, viewMode = 'grid', onClick }: EnhancedACPCardProps) => {
+
+  const getStatusColor = (status: string) => {
     const cleanStatus = status?.toLowerCase() || '';
     
     switch (cleanStatus) {
@@ -35,14 +40,14 @@ const EnhancedACPCard = ({ acp, viewMode = 'grid', onClick }) => {
     }
   };
 
-  const getComplexityIndicator = (complexity) => {
+  const getComplexityIndicator = (complexity?: string) => {
     const levels = {
       'Low': { bars: 1, color: 'bg-green-500' },
       'Medium': { bars: 2, color: 'bg-yellow-500' },
       'High': { bars: 3, color: 'bg-orange-500' },
       'Very High': { bars: 4, color: 'bg-red-500' },
     };
-    const config = levels[complexity] || levels['Medium'];
+    const config = levels[complexity as keyof typeof levels] || levels['Medium'];
 
     return (
       <div className="flex items-center gap-1" title={`Complexity: ${complexity}`}>
@@ -61,7 +66,14 @@ const EnhancedACPCard = ({ acp, viewMode = 'grid', onClick }) => {
     );
   };
 
-  const MetadataItem = ({ icon: Icon, label, value, colorClass = '' }) => (
+  interface MetadataItemProps {
+    icon: LucideIcon;
+    label: string;
+    value?: string | number;
+    colorClass?: string;
+  }
+
+  const MetadataItem = ({ icon: Icon, label, value, colorClass = '' }: MetadataItemProps) => (
     <div className={`flex items-center gap-1.5 text-muted-foreground ${colorClass}`}>
       <Icon className="w-4 h-4" />
       <span className="text-xs font-medium">{label}</span>

--- a/src/components/AddToMetaMask.tsx
+++ b/src/components/AddToMetaMask.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Wallet, Check, AlertCircle, ExternalLink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Chain } from '../types';

--- a/src/components/AuthorAvatar.tsx
+++ b/src/components/AuthorAvatar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { User } from 'lucide-react';
 
 export interface AuthorAvatarProps {

--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { User, Calendar, ExternalLink, Twitter, Linkedin, Globe, Github, Users, X, Mail } from 'lucide-react';
+import { User, Calendar, Twitter, Linkedin, Globe, Github, Users, X, Mail } from 'lucide-react';
 
 export interface AuthorProfile {
   name: string;

--- a/src/components/AvalancheNetworkMetrics.tsx
+++ b/src/components/AvalancheNetworkMetrics.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import { usePolling } from '../hooks/usePolling';
 import { useSearchParams } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
-import { Chart as ChartJSInstance } from 'chart.js';
+import { Chart as ChartJSInstance, ChartData } from 'chart.js';
 import { format, parseISO } from 'date-fns';
 import html2canvas from 'html2canvas';
 import { TimeframeOption } from '../types';
@@ -809,7 +809,7 @@ export function AvalancheNetworkMetrics() {
               {[7, 30, 90, 360].map((days) => (
                 <button
                   key={days}
-                  onClick={() => handleTimeframeChange(days)}
+                  onClick={() => handleTimeframeChange(days as TimeframeOption)}
                   className={`h-8 px-3 rounded-lg text-xs font-medium border transition-colors ${
                     timeframe === days
                       ? 'bg-[#ef4444]/15 border-[#ef4444]/30 text-[#ef4444]'
@@ -933,10 +933,10 @@ export function AvalancheNetworkMetrics() {
 
       <div className="h-[300px] sm:h-[400px]">
         {chartData ? (
-          <Line 
-            ref={chartRef} 
-            data={chartData} 
-            options={options} 
+          <Line
+            ref={chartRef}
+            data={chartData as ChartData<'line'>}
+            options={options}
             plugins={[lineShadowPlugin, crosshairPlugin, watermarkPlugin]}
           />
         ) : (

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, Clock, Tag, ArrowRight } from 'lucide-react';
+import { Calendar, Tag } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { BlogPost, formatBlogDate, calculateReadTime } from '../api/blogApi';
+import { BlogPost, formatBlogDate } from '../api/blogApi';
 import { AuthorCard } from './AuthorCard';
 import { getBlogPostImageUrl } from '../utils/imageExtractor';
 
@@ -12,7 +11,6 @@ interface BlogCardProps {
 }
 
 export function BlogCard({ post, featured = false }: BlogCardProps) {
-    const readTime = post.readTime || calculateReadTime(post.content || '');
     const formattedDate = formatBlogDate(post.publishedAt || '');
     const imageUrl = getBlogPostImageUrl(post);
 

--- a/src/components/ChainSpecificMetrics.tsx
+++ b/src/components/ChainSpecificMetrics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJSInstance } from 'chart.js';
 import { format, parseISO } from 'date-fns';
@@ -316,7 +316,7 @@ export function ChainSpecificMetrics() {
           try {
             const data = await getDailyActiveAddresses(lookupId, 7);
             const latest = data?.[data.length - 1];
-            const value = Number(latest?.activeAddresses ?? latest?.value ?? 0);
+            const value = Number(latest?.activeAddresses ?? (latest as { value?: number } | undefined)?.value ?? 0);
             results[chain.chainId] = Number.isFinite(value) ? value : 0;
           } catch {
             results[chain.chainId] = 0;
@@ -342,6 +342,7 @@ export function ChainSpecificMetrics() {
     if (!selectedChain) return;
 
     async function fetchMetrics() {
+      if (!selectedChain) return;
       const chainId = selectedChain.originalChainId || selectedChain.chainId;
       const evmChainIdStr = selectedChain.evmChainId ? String(selectedChain.evmChainId) : chainId;
 

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Filter, Users, RotateCcw } from 'lucide-react';
+import { X, Filter, RotateCcw } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 type ValidatorFilter = 'active' | 'all' | 'inactive';

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 interface SEOProps {

--- a/src/components/TeleporterSankeyDiagram.tsx
+++ b/src/components/TeleporterSankeyDiagram.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { usePolling } from '../hooks/usePolling';
 import * as d3 from 'd3';
-import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
-import { format } from 'date-fns';
+import { sankey, sankeyLinkHorizontal, type SankeyNodeMinimal, type SankeyLinkMinimal } from 'd3-sankey';
 import { RefreshCw, AlertTriangle } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { useNavigate } from 'react-router-dom';
@@ -29,7 +28,7 @@ interface TeleporterData {
   };
 }
 
-interface SankeyNode extends d3.SankeyNode<SankeyNode, SankeyLink> {
+interface SankeyNode extends SankeyNodeMinimal<SankeyNode, SankeyLink> {
   name: string;
   id: string;
   color?: string;
@@ -37,7 +36,7 @@ interface SankeyNode extends d3.SankeyNode<SankeyNode, SankeyLink> {
   originalName?: string;
 }
 
-interface SankeyLink extends d3.SankeyLink<SankeyNode, SankeyLink> {
+interface SankeyLink extends SankeyLinkMinimal<SankeyNode, SankeyLink> {
   source: SankeyNode;
   target: SankeyNode;
   value: number;
@@ -59,25 +58,6 @@ const formatChainName = (name: string) => {
   return name;
 };
 
-// Function to find chain ID from chain name
-const findChainId = (chainName: string) => {
-  // Map of known chain names to their IDs
-  const chainMap: Record<string, string> = {
-    'Avalanche (C-Chain)': 'C',
-    'C-Chain': 'C',
-    'Dexalot L1': 'dexalot',
-    'Dexalot': 'dexalot',
-    'zeroone Mainnet L1': 'zeroone',
-    'ZeroOne': 'zeroone',
-    'Lamina1 L1': 'lamina1',
-    'Lamina1': 'lamina1',
-    'PLYR PHI L1': 'plyr',
-    'PLYR': 'plyr',
-  };
-  
-  return chainMap[chainName] || null;
-};
-
 // Maximum animation cycles per particle to prevent infinite loops
 const MAX_PARTICLE_CYCLES = 30;
 
@@ -91,9 +71,9 @@ export function TeleporterSankeyDiagram({ timeframe, onTimeframeChange }: Telepo
   const [data, setData] = useState<TeleporterData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [hoveredLink, setHoveredLink] = useState<SankeyLink | null>(null);
-  const [hoveredNode, setHoveredNode] = useState<SankeyNode | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const [hoveredLink] = useState<SankeyLink | null>(null);
+  const [, setHoveredNode] = useState<SankeyNode | null>(null);
+  const [, setTooltipPosition] = useState({ x: 0, y: 0 });
   const [selectedChain, setSelectedChain] = useState<string | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -577,7 +557,7 @@ export function TeleporterSankeyDiagram({ timeframe, onTimeframeChange }: Telepo
         .attr('pointer-events', 'none');
       
       // Add value labels, hidden by default
-      const valueLabels = nodes_g.append('text')
+      nodes_g.append('text')
         .attr('x', d => d.x0 < width / 2 ? d.x1 - d.x0 + 6 : -6)
         .attr('y', d => (d.y1 - d.y0) / 2 + 16)
         .attr('dy', '0.35em')
@@ -600,7 +580,7 @@ export function TeleporterSankeyDiagram({ timeframe, onTimeframeChange }: Telepo
         .on('mousemove', function(event) {
           setTooltipPosition({ x: event.pageX, y: event.pageY });
         })
-        .on('mouseout', function(event, d) {
+        .on('mouseout', function(_event, _d) {
           setHoveredNode(null);
           d3.select(this).select('.value-label').attr('opacity', 0);
         })
@@ -647,36 +627,6 @@ export function TeleporterSankeyDiagram({ timeframe, onTimeframeChange }: Telepo
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [data]);
-
-  // Format large numbers with appropriate suffixes
-  const formatNumber = (num: number): string => {
-    if (num >= 1000000) {
-      return (num / 1000000).toFixed(1) + 'M';
-    } else if (num >= 1000) {
-      return (num / 1000).toFixed(1) + 'K';
-    } else {
-      return num.toString();
-    }
-  };
-
-  // Calculate time since last update
-  const getTimeSinceUpdate = (): string => {
-    if (!data?.metadata.updatedAt) return 'Unknown';
-    
-    const updateTime = new Date(data.metadata.updatedAt);
-    const now = new Date();
-    const diffMs = now.getTime() - updateTime.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    
-    if (diffMins < 1) return 'Just now';
-    if (diffMins < 60) return `${diffMins} min${diffMins === 1 ? '' : 's'} ago`;
-    
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-    
-    const diffDays = Math.floor(diffHours / 24);
-    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  };
 
   if (loading) {
     return (

--- a/src/components/branding/BrandColors.tsx
+++ b/src/components/branding/BrandColors.tsx
@@ -5,7 +5,7 @@ interface BrandColorsProps {
   theme: 'dark' | 'light';
 }
 
-export function BrandColors({ theme }: BrandColorsProps) {
+export function BrandColors({}: BrandColorsProps) {
   const [copiedColor, setCopiedColor] = useState<string | null>(null);
 
   const copyToClipboard = (text: string, label: string) => {

--- a/src/components/branding/ui/select.tsx
+++ b/src/components/branding/ui/select.tsx
@@ -65,7 +65,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/src/components/branding/ui/tooltip.tsx
+++ b/src/components/branding/ui/tooltip.tsx
@@ -46,7 +46,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-[var(--radix-tooltip-content-transform-origin)] rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}

--- a/src/components/comparison/ComparisonChart.tsx
+++ b/src/components/comparison/ComparisonChart.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from 'react';
 import { Line } from 'react-chartjs-2';
+import type { ChartOptions, Plugin } from 'chart.js';
 import { format } from 'date-fns';
 import { DailyTxCount, DailyActiveAddresses, MaxTPSHistory, GasUsedHistory, AvgGasPriceHistory, FeesPaidHistory } from '../../types';
 import { useTheme } from '../../hooks/useTheme';
@@ -381,7 +382,7 @@ export const ComparisonChart = memo(function ComparisonChart({
       >
         <h3 className="text-lg font-semibold text-foreground mb-4">{title}</h3>
         <div className="h-[400px]" onMouseLeave={() => onHoverChain?.(null)}>
-          <Line data={chartData} options={options} plugins={[endLabelPlugin, crosshairPlugin, watermarkPlugin]} />
+          <Line data={chartData} options={options as unknown as ChartOptions<'line'>} plugins={[endLabelPlugin as unknown as Plugin<'line'>, crosshairPlugin, watermarkPlugin]} />
         </div>
       </motion.div>
     </AnimatePresence>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -52,7 +52,7 @@ const dockItems: { id: string; path: string; icon: typeof LayoutGrid; label: str
   { id: 'burn', path: '/burn', icon: Flame, label: 'Burn' },
   { id: 'acps', path: '/acps', icon: FileText, label: 'ACPs' },
   { id: 'blog', path: '/blog', icon: BookOpen, label: 'Blog' },
-  { id: 'api', path: '/api', icon: Code, label: 'API', disabled: true },
+  { id: 'api', path: '/api', icon: Code, label: 'API' },
 ];
 
 function MobileDock() {

--- a/src/components/layout/SearchPalette.tsx
+++ b/src/components/layout/SearchPalette.tsx
@@ -84,6 +84,7 @@ const PAGES: Result[] = [
   { id: 'page-stablecoins', type: 'page', title: 'Stablecoins', subtitle: 'Supply, holders, and 24h activity', to: '/stablecoins' },
   { id: 'page-acps', type: 'page', title: 'ACPs', subtitle: 'Avalanche Community Proposals', to: '/acps' },
   { id: 'page-blog', type: 'page', title: 'Blog', subtitle: 'Insights & research', to: '/blog' },
+  { id: 'page-api', type: 'page', title: 'API Playground', subtitle: 'Test the REST & WebSocket APIs', to: '/api' },
   { id: 'page-brand', type: 'page', title: 'Brand', subtitle: 'Brand guidelines', to: '/brand' },
 ];
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const primaryNav: NavItem[] = [
   { id: 'burn', label: 'Burn', path: '/burn', icon: Flame, badge: 'NEW' },
   { id: 'acps', label: 'ACPs', path: '/acps', icon: FileText },
   { id: 'blog', label: 'Blog', path: '/blog', icon: BookOpen },
-  { id: 'api', label: 'API', path: '/api', icon: Code, disabled: true },
+  { id: 'api', label: 'API', path: '/api', icon: Code, badge: 'NEW' },
 ];
 
 function isActive(pathname: string, path: string) {

--- a/src/components/playground/BookmarkBar.tsx
+++ b/src/components/playground/BookmarkBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Bookmark, ChevronDown, ChevronUp, X } from 'lucide-react';
 import {
   Collapsible,

--- a/src/components/playground/HistoryBar.tsx
+++ b/src/components/playground/HistoryBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { ChevronDown, ChevronUp, Clock } from 'lucide-react';
 import {
   Collapsible,

--- a/src/components/playground/LandingState.tsx
+++ b/src/components/playground/LandingState.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import {
   Blocks,
   Network,

--- a/src/components/playground/ResponsePanel.tsx
+++ b/src/components/playground/ResponsePanel.tsx
@@ -1,7 +1,203 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Terminal, AlertCircle, Copy, ChevronRight, ChevronDown, Link } from 'lucide-react';
+import { Link as RouterLink } from 'react-router-dom';
 import { Skeleton } from '../branding/ui/skeleton';
 import { EndpointDef } from './endpointCatalog';
+import { smoothLinePath } from '../../utils/chartConfig';
+import { fieldHint } from './fieldHints';
+import { ChartWatermark } from '../ChartWatermark';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../branding/ui/tooltip';
+
+// A response key with a known meaning → dotted underline + styled tooltip.
+function KeyLabel({ name }: { name: string }) {
+  const hint = fieldHint(name);
+  const span = (
+    <span
+      className={
+        'text-[#60a5fa]' +
+        (hint ? ' cursor-help underline decoration-dotted underline-offset-2 decoration-muted-foreground/60' : '')
+      }
+    >
+      {JSON.stringify(name)}
+    </span>
+  );
+  if (!hint) return span;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{span}</TooltipTrigger>
+      <TooltipContent
+        side="top"
+        align="start"
+        className="max-w-[260px] bg-popover border border-border text-foreground text-[11px] normal-case font-normal tracking-normal leading-relaxed px-3 py-2 shadow-xl [&>span]:hidden"
+      >
+        {hint}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// Fields we have a detail page for → make their values clickable in responses.
+// Only validators today (/validator/:id resolves a node_id or validation_id
+// directly). Chains resolve by app slug, not the API id, so they're not linked.
+const VALIDATOR_KEYS = new Set(['node_id', 'validation_id']);
+function validatorLink(key: string | undefined, value: unknown): string | null {
+  if (!key || !VALIDATOR_KEYS.has(key) || typeof value !== 'string' || !value) return null;
+  return `/validator/${encodeURIComponent(value)}`;
+}
+
+// ─── Chart view ────────────────────────────────────────────────────────────
+// Detects a time series in the response and renders a compact line chart.
+// Handles the three timeseries shapes the API returns.
+
+interface ChartSeries {
+  label: string;
+  points: { t: number; y: number }[];
+}
+
+function extractSeries(resp: unknown): ChartSeries | null {
+  if (!resp || typeof resp !== 'object') return null;
+  const d = (resp as Record<string, unknown>).data;
+  if (!d) return null;
+  const toPoints = (arr: unknown[], key: string) =>
+    (arr as Record<string, unknown>[])
+      .map((p) => ({ t: Date.parse(String(p.period)), y: Number(p[key]) }))
+      .filter((p) => Number.isFinite(p.t) && Number.isFinite(p.y))
+      .sort((a, b) => a.t - b.t);
+
+  // metrics timeseries: data.data = [{ period, value }]
+  if (!Array.isArray(d)) {
+    const obj = d as Record<string, unknown>;
+    if (Array.isArray(obj.data) && obj.data.length && 'period' in (obj.data[0] as object)) {
+      return { label: String(obj.metric_name ?? 'value'), points: toPoints(obj.data, 'value') };
+    }
+    // fee burn: data.series = [{ period, total_burned, ... }]
+    if (Array.isArray(obj.series) && obj.series.length && 'period' in (obj.series[0] as object)) {
+      return { label: 'total burned', points: toPoints(obj.series, 'total_burned') };
+    }
+  }
+  // stablecoin timeseries: data = [{ token, metric_name, data: [{period, value}] }]
+  if (Array.isArray(d) && d.length) {
+    const first = d[0] as Record<string, unknown>;
+    if (Array.isArray(first.data) && first.data.length && 'period' in (first.data[0] as object)) {
+      const label = String(first.token ?? first.metric_name ?? 'series') + (d.length > 1 ? ` (1 of ${d.length})` : '');
+      return { label, points: toPoints(first.data, 'value') };
+    }
+  }
+  return null;
+}
+
+function abbrev(v: number): string {
+  const a = Math.abs(v);
+  if (a >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (a >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (a >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return String(Number(v.toFixed(2)));
+}
+
+function ChartView({ series }: { series: ChartSeries }) {
+  const pts = series.points;
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hover, setHover] = useState<number | null>(null);
+  if (pts.length < 2) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+        Not enough data points to chart.
+      </div>
+    );
+  }
+  const W = 760, H = 260, M = { top: 16, right: 20, bottom: 28, left: 64 };
+  const iw = W - M.left - M.right, ih = H - M.top - M.bottom;
+  const xs = pts.map((p) => p.t), ys = pts.map((p) => p.y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const sx = (t: number) => M.left + ((t - minX) / (maxX - minX || 1)) * iw;
+  const sy = (y: number) => M.top + ih - ((y - minY) / (maxY - minY || 1)) * ih;
+  const line = smoothLinePath(pts.map((p) => ({ x: sx(p.t), y: sy(p.y) })));
+  const floor = M.top + ih;
+  const area = `${line} L${sx(maxX).toFixed(1)},${floor} L${sx(minX).toFixed(1)},${floor} Z`;
+  const fmtDate = (t: number) => new Date(t).toISOString().slice(0, 10);
+  const ticks = [maxY, (minY + maxY) / 2, minY];
+
+  // Map the pointer to the nearest data point (in viewBox space so it works
+  // regardless of the SVG's rendered size).
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const vbX = ((e.clientX - rect.left) / rect.width) * W;
+    let best = 0, bestD = Infinity;
+    for (let i = 0; i < pts.length; i++) {
+      const d = Math.abs(sx(pts[i].t) - vbX);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    setHover(best);
+  };
+
+  const hp = hover !== null ? pts[hover] : null;
+  const hoverPct = hp ? (sx(hp.t) / W) * 100 : 0;
+  // Flip the tooltip toward the interior near the edges so it doesn't clip.
+  const tipTransform =
+    hoverPct < 12 ? 'translate(0, -100%)'
+      : hoverPct > 88 ? 'translate(-100%, -100%)'
+      : 'translate(-50%, -100%)';
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="text-xs text-muted-foreground mb-3">{series.label} · {pts.length} points</div>
+      <div className="relative w-full">
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full h-auto block"
+          role="img"
+          aria-label={`${series.label} over time`}
+          onMouseMove={onMove}
+          onMouseLeave={() => setHover(null)}
+        >
+          <defs>
+            <linearGradient id="pg-series-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#ef4444" stopOpacity={0.28} />
+              <stop offset="100%" stopColor="#ef4444" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          {ticks.map((tick, i) => (
+            <g key={i}>
+              <line x1={M.left} x2={W - M.right} y1={sy(tick)} y2={sy(tick)} stroke="currentColor" strokeOpacity={0.08} />
+              <text x={M.left - 8} y={sy(tick)} textAnchor="end" dominantBaseline="middle" className="fill-muted-foreground" fontSize={10}>
+                {abbrev(tick)}
+              </text>
+            </g>
+          ))}
+          <path d={area} fill="url(#pg-series-fill)" />
+          <path d={line} fill="none" stroke="#ef4444" strokeWidth={1.75} strokeLinejoin="round" strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+          <text x={M.left} y={H - 8} textAnchor="start" className="fill-muted-foreground" fontSize={10}>{fmtDate(minX)}</text>
+          <text x={W - M.right} y={H - 8} textAnchor="end" className="fill-muted-foreground" fontSize={10}>{fmtDate(maxX)}</text>
+          {hp && (
+            <g>
+              <line x1={sx(hp.t)} x2={sx(hp.t)} y1={M.top} y2={floor} stroke="currentColor" strokeOpacity={0.25} strokeDasharray="3 3" />
+              <circle cx={sx(hp.t)} cy={sy(hp.y)} r={3.5} fill="#ef4444" stroke="var(--background)" strokeWidth={1.5} />
+            </g>
+          )}
+        </svg>
+        <ChartWatermark />
+        {hp && (
+          <div
+            className="pointer-events-none absolute z-10 px-2 py-1 rounded-md bg-card border border-border shadow-md text-[11px] whitespace-nowrap"
+            style={{
+              left: `${hoverPct}%`,
+              top: `${(sy(hp.y) / H) * 100}%`,
+              transform: tipTransform,
+              marginTop: -8,
+            }}
+          >
+            <div className="font-mono font-semibold text-foreground">{hp.y.toLocaleString()}</div>
+            <div className="text-muted-foreground">{fmtDate(hp.t)}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 // ─── StatusBadge ────────────────────────────────────────────────────────────
 
@@ -15,10 +211,10 @@ function StatusBadge({ status }: { status: number }) {
       ? 'bg-blue-500/15 text-blue-600 dark:text-blue-400'
       : 'bg-green-500/15 text-green-600 dark:text-green-400';
   const label =
-    status >= 500
+    status >= 400
       ? `${status} Error`
-      : status >= 400
-      ? `${status} Error`
+      : status >= 300
+      ? `${status} Redirect`
       : `${status} OK`;
   return (
     <span
@@ -33,55 +229,76 @@ function StatusBadge({ status }: { status: number }) {
 
 function RateLimitCard({
   retryAfter,
+  autoRetry,
   onRetry,
 }: {
   retryAfter: number;
+  autoRetry: boolean;
   onRetry: () => void;
 }) {
   const [seconds, setSeconds] = useState(retryAfter);
-  const cancelledRef = useRef(false);
+  // When auto-retry is exhausted we start paused, showing a manual retry button.
+  const [paused, setPaused] = useState(!autoRetry);
+  const firedRef = useRef(false);
   const onRetryRef = useRef(onRetry);
   useEffect(() => { onRetryRef.current = onRetry; });
 
   useEffect(() => {
-    cancelledRef.current = false;
-    return () => {
-      cancelledRef.current = true;
-    };
-  }, []);
-
-  useEffect(() => {
+    if (paused) return;
     if (seconds <= 0) {
-      if (!cancelledRef.current) onRetryRef.current();
+      if (!firedRef.current) {
+        firedRef.current = true;
+        onRetryRef.current();
+      }
       return;
     }
     const t = setTimeout(() => setSeconds((s) => s - 1), 1000);
     return () => clearTimeout(t);
-  }, [seconds]);
+  }, [seconds, paused]);
 
   return (
     <div className="m-6 p-4 rounded-lg bg-orange-500/10 border border-orange-500/20">
       <div className="font-medium text-orange-700 dark:text-orange-400 mb-2">
         Rate Limited
       </div>
-      <p className="text-sm text-foreground mb-3">
-        Retrying in{' '}
-        <span className="font-mono font-bold">{seconds}s</span>...
-      </p>
-      <button
-        onClick={() => {
-          cancelledRef.current = true;
-          setSeconds(0);
-        }}
-        className="text-xs text-muted-foreground hover:text-foreground"
-      >
-        Cancel auto-retry
-      </button>
+      {paused ? (
+        <>
+          <p className="text-sm text-foreground mb-3">
+            {autoRetry
+              ? 'Auto-retry cancelled.'
+              : 'Auto-retry paused after several attempts.'}{' '}
+            You are being rate limited (60 req/min, burst 10). Wait a moment, then retry.
+          </p>
+          <button
+            onClick={() => onRetryRef.current()}
+            className="text-xs px-3 py-1.5 rounded-lg bg-[#ef4444] hover:bg-[#dc2626] text-white font-medium transition-colors"
+          >
+            Retry now
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-foreground mb-3">
+            Retrying in{' '}
+            <span className="font-mono font-bold">{seconds}s</span>...
+          </p>
+          <button
+            onClick={() => setPaused(true)}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Cancel auto-retry
+          </button>
+        </>
+      )}
     </div>
   );
 }
 
 // ─── JSON Viewer ─────────────────────────────────────────────────────────────
+
+// Max array items rendered per node in the tree viewer (guards against freezing
+// on very large / accumulated responses; full data stays available via Copy JSON).
+const ARRAY_RENDER_CAP = 100;
 
 interface ExpandSignals {
   expandSig: number;
@@ -93,9 +310,10 @@ const ExpandContext = React.createContext<ExpandSignals>({ expandSig: 0, collaps
 interface JsonNodeProps {
   value: unknown;
   depth: number;
+  objKey?: string;
 }
 
-function JsonNode({ value, depth }: JsonNodeProps) {
+function JsonNode({ value, depth, objKey }: JsonNodeProps) {
   const { expandSig, collapseSig, generation } = React.useContext(ExpandContext);
   const isArray = Array.isArray(value);
   const isObject =
@@ -147,6 +365,18 @@ function JsonNode({ value, depth }: JsonNodeProps) {
   }
 
   if (typeof value === 'string') {
+    const link = validatorLink(objKey, value);
+    if (link) {
+      return (
+        <RouterLink
+          to={link}
+          title="Open validator"
+          className="text-[#4ade80] underline decoration-dotted underline-offset-2 hover:text-[#ef4444] transition-colors"
+        >
+          {JSON.stringify(value)}
+        </RouterLink>
+      );
+    }
     return <span className="text-[#4ade80]">{JSON.stringify(value)}</span>;
   }
 
@@ -179,12 +409,17 @@ function JsonNode({ value, depth }: JsonNodeProps) {
           <ChevronDown className="w-3 h-3 text-muted-foreground" />
         </button>
         <span className="text-muted-foreground">[</span>
-        {arr.map((item, i) => (
+        {arr.slice(0, ARRAY_RENDER_CAP).map((item, i) => (
           <div key={i} style={indent}>
             <JsonNode value={item} depth={depth + 1} />
             {i < arr.length - 1 && <span className="text-muted-foreground">,</span>}
           </div>
         ))}
+        {arr.length > ARRAY_RENDER_CAP && (
+          <div style={indent} className="text-muted-foreground text-xs italic">
+            … {(arr.length - ARRAY_RENDER_CAP).toLocaleString()} more item{arr.length - ARRAY_RENDER_CAP === 1 ? '' : 's'} not shown — use Copy JSON for the full response
+          </div>
+        )}
         <div style={{ paddingLeft: `${(depth) * 16}px` }}>
           <span className="text-muted-foreground">]</span>
         </div>
@@ -225,9 +460,9 @@ function JsonNode({ value, depth }: JsonNodeProps) {
         <span className="text-muted-foreground">{'{'}</span>
         {keys.map((key, i) => (
           <div key={key} style={indent}>
-            <span className="text-[#60a5fa]">{JSON.stringify(key)}</span>
+            <KeyLabel name={key} />
             <span className="text-muted-foreground">: </span>
-            <JsonNode value={obj[key]} depth={depth + 1} />
+            <JsonNode value={obj[key]} depth={depth + 1} objKey={key} />
             {i < keys.length - 1 && <span className="text-muted-foreground">,</span>}
           </div>
         ))}
@@ -243,12 +478,20 @@ function JsonNode({ value, depth }: JsonNodeProps) {
 
 // ─── Copy Link Button ────────────────────────────────────────────────────────
 
-function CopyLinkButton() {
+function CopyLinkButton({ getShareUrl }: { getShareUrl?: () => string }) {
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
-    const url = new URL(window.location.href);
-    url.searchParams.set('autorun', '1');
-    navigator.clipboard.writeText(url.toString()).then(() => {
+    // Prefer a URL built from current state (avoids the debounced address-bar
+    // sync lagging behind recent param edits); fall back to the live location.
+    let text: string;
+    if (getShareUrl) {
+      text = getShareUrl();
+    } else {
+      const url = new URL(window.location.href);
+      url.searchParams.set('autorun', '1');
+      text = url.toString();
+    }
+    navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -267,6 +510,78 @@ function CopyLinkButton() {
 
 // ─── ResponsePanel ────────────────────────────────────────────────────────────
 
+// ─── Table view ──────────────────────────────────────────────────────────
+// Renders a list response (data[] of flat objects) as a scrollable table —
+// far more scannable than raw JSON for blocks/txs/validators/chains/etc.
+
+function formatCell(v: unknown): string {
+  if (v === null || v === undefined) return '—';
+  if (typeof v === 'object') return Array.isArray(v) ? `[${(v as unknown[]).length}]` : '{…}';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  return String(v);
+}
+
+function TableView({ rows, columns }: { rows: Record<string, unknown>[]; columns: string[] }) {
+  return (
+    <div className="flex-1 overflow-auto scrollbar-hide">
+      <table className="w-full text-xs font-mono border-collapse">
+        <thead className="sticky top-0 z-10 bg-background">
+          <tr className="border-b border-border">
+            {columns.map((c) => {
+              const hint = fieldHint(c);
+              return (
+                <th key={c} className="text-left font-semibold text-muted-foreground px-3 py-2 whitespace-nowrap">
+                  {hint ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-help underline decoration-dotted underline-offset-2 decoration-muted-foreground/50">{c}</span>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="top"
+                        align="start"
+                        className="max-w-[260px] bg-popover border border-border text-foreground text-[11px] normal-case font-normal tracking-normal leading-relaxed px-3 py-2 shadow-xl [&>span]:hidden"
+                      >
+                        {hint}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    c
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-b border-border/50 hover:bg-accent/40">
+              {columns.map((c) => {
+                const text = formatCell(row[c]);
+                const link = validatorLink(c, row[c]);
+                return (
+                  <td
+                    key={c}
+                    title={text.length > 28 ? text : undefined}
+                    className="px-3 py-1.5 whitespace-nowrap max-w-[22rem] truncate tabular-nums text-foreground/90"
+                  >
+                    {link ? (
+                      <RouterLink to={link} className="underline decoration-dotted underline-offset-2 hover:text-[#ef4444] transition-colors">
+                        {text}
+                      </RouterLink>
+                    ) : (
+                      text
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 interface ResponsePanelProps {
   response: unknown | null;
   status: number | null;
@@ -277,7 +592,12 @@ interface ResponsePanelProps {
   suggestedNext: EndpointDef[];
   onSuggestSelect: (id: string) => void;
   onRetryAfter?: (seconds: number) => void;
+  headers?: Record<string, string> | null;
+  getShareUrl?: () => string;
 }
+
+// Cap on consecutive automatic retries before we hand control back to the user.
+const MAX_AUTO_RETRIES = 3;
 
 function countLines(data: unknown): number {
   try {
@@ -297,11 +617,23 @@ export function ResponsePanel({
   suggestedNext,
   onSuggestSelect,
   onRetryAfter,
+  headers,
+  getShareUrl,
 }: ResponsePanelProps) {
   const [copiedJson, setCopiedJson] = useState(false);
+  const [showHeaders, setShowHeaders] = useState(false);
   const [generation, setGeneration] = useState(0);
   const [expandSig, setExpandSig] = useState(0);
   const [collapseSig, setCollapseSig] = useState(0);
+  const [viewMode, setViewMode] = useState<'json' | 'table' | 'chart'>('json');
+  // Count consecutive 429s so we stop auto-retrying instead of looping forever.
+  // Note: `status` is briefly null while a retry is in flight — don't treat that
+  // transient as a reset, or the counter would never climb.
+  const [autoRetries, setAutoRetries] = useState(0);
+  useEffect(() => {
+    if (status === 429) setAutoRetries((n) => n + 1);
+    else if (status !== null) setAutoRetries(0);
+  }, [response, status]);
 
   const copyJson = useCallback(() => {
     try {
@@ -323,6 +655,7 @@ export function ResponsePanel({
     if (prevResponseRef.current !== response) {
       prevResponseRef.current = response;
       setGeneration((g) => g + 1);
+      setViewMode('json');
     }
   }, [response]);
 
@@ -384,6 +717,7 @@ export function ResponsePanel({
       <RateLimitCard
         key={`${retryAfter}-${durationMs}`}
         retryAfter={retryAfter}
+        autoRetry={autoRetries <= MAX_AUTO_RETRIES}
         onRetry={() => onRetryAfter(retryAfter)}
       />
     );
@@ -405,17 +739,17 @@ export function ResponsePanel({
             )}
           </div>
           <div className="m-6 p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-            {err.code && (
+            {!!err.code && (
               <div className="font-mono text-sm font-medium text-yellow-700 dark:text-yellow-400 mb-2">
                 {String(err.code)}
               </div>
             )}
-            {err.message && (
+            {!!err.message && (
               <div className="text-sm text-foreground mb-1">
                 {String(err.message)}
               </div>
             )}
-            {err.details && (
+            {!!err.details && (
               <div className="text-xs text-muted-foreground font-mono">
                 {String(err.details)}
               </div>
@@ -434,7 +768,37 @@ export function ResponsePanel({
   const dataField = !Array.isArray(responseObj) ? responseObj?.data : responseObj;
   const lineCount = countLines(response);
 
+  // A table is feasible when data is a non-empty array of plain objects.
+  const tableRows =
+    Array.isArray(dataField) &&
+    dataField.length > 0 &&
+    dataField.every((r) => r && typeof r === 'object' && !Array.isArray(r))
+      ? (dataField as Record<string, unknown>[])
+      : null;
+  const columns = tableRows
+    ? Array.from(
+        tableRows.slice(0, 100).reduce((set, row) => {
+          Object.keys(row).forEach((k) => set.add(k));
+          return set;
+        }, new Set<string>()),
+      )
+    : [];
+  const chartSeries = extractSeries(response);
+  const showTable = tableRows !== null && viewMode === 'table';
+  const showChart = chartSeries !== null && viewMode === 'chart';
+  const jsonView = !showTable && !showChart;
+  const headerEntries = headers ? Object.entries(headers) : [];
+  // Rate-limit headers (token bucket): Limit = burst capacity, Remaining =
+  // tokens left, Reset = epoch second the bucket refills. Sustained 60/min.
+  const rlLimit = headers?.['x-ratelimit-limit'] != null ? Number(headers['x-ratelimit-limit']) : null;
+  const rlRemaining = headers?.['x-ratelimit-remaining'] != null ? Number(headers['x-ratelimit-remaining']) : null;
+  const rlResetIn =
+    headers?.['x-ratelimit-reset'] != null
+      ? Math.max(0, Math.round(Number(headers['x-ratelimit-reset']) - Date.now() / 1000))
+      : null;
+
   return (
+    <TooltipProvider delayDuration={150}>
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       {/* Summary bar */}
       <div className="flex items-center gap-3 px-6 py-3 border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-10 flex-wrap gap-y-2 flex-shrink-0">
@@ -452,26 +816,78 @@ export function ResponsePanel({
             {Number(meta.total).toLocaleString()} total
           </span>
         )}
-        {meta?.has_more && (
+        {!!meta?.has_more && (
           <span className="text-xs px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-600 dark:text-blue-400">
             has more
           </span>
         )}
+        {rlRemaining !== null && rlLimit !== null && (
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              rlRemaining === 0
+                ? 'bg-red-500/15 text-red-600 dark:text-red-400'
+                : rlRemaining <= 3
+                ? 'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {rlRemaining}/{rlLimit} req left
+            {rlRemaining === 0 && rlResetIn !== null ? ` · resets ${rlResetIn}s` : ''}
+          </span>
+        )}
         <div className="ml-auto flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">{lineCount} lines</span>
-          <button
-            onClick={expandAll}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Expand all
-          </button>
-          <button
-            onClick={collapseAll}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Collapse all
-          </button>
-          <CopyLinkButton />
+          {(tableRows || chartSeries) && (
+            <div className="flex items-center rounded-md border border-border overflow-hidden text-xs">
+              <button
+                onClick={() => setViewMode('json')}
+                className={`px-2 py-0.5 transition-colors ${jsonView ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              >
+                JSON
+              </button>
+              {tableRows && (
+                <button
+                  onClick={() => setViewMode('table')}
+                  className={`px-2 py-0.5 border-l border-border transition-colors ${showTable ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                >
+                  Table
+                </button>
+              )}
+              {chartSeries && (
+                <button
+                  onClick={() => setViewMode('chart')}
+                  className={`px-2 py-0.5 border-l border-border transition-colors ${showChart ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                >
+                  Chart
+                </button>
+              )}
+            </div>
+          )}
+          {jsonView && <span className="text-xs text-muted-foreground">{lineCount} lines</span>}
+          {jsonView && (
+            <button
+              onClick={expandAll}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Expand all
+            </button>
+          )}
+          {jsonView && (
+            <button
+              onClick={collapseAll}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Collapse all
+            </button>
+          )}
+          {headerEntries.length > 0 && (
+            <button
+              onClick={() => setShowHeaders((s) => !s)}
+              className={`text-xs transition-colors ${showHeaders ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              Headers
+            </button>
+          )}
+          <CopyLinkButton getShareUrl={getShareUrl} />
           <button
             onClick={copyJson}
             className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
@@ -482,7 +898,29 @@ export function ResponsePanel({
         </div>
       </div>
 
+      {/* Response headers (only those readable cross-origin via CORS) */}
+      {showHeaders && headerEntries.length > 0 && (
+        <div className="px-6 py-3 border-b border-border bg-muted/30 flex-shrink-0 text-xs font-mono space-y-1">
+          {headerEntries.map(([k, v]) => (
+            <div key={k} className="flex gap-2">
+              <span className="text-[#60a5fa] shrink-0">{k}:</span>
+              <span className="text-foreground/80 break-all">{v}</span>
+            </div>
+          ))}
+          <div className="text-[10px] text-muted-foreground/70 font-sans pt-1">
+            Only CORS-safelisted headers are visible to the browser (Cache-Control, Content-Type, …).
+          </div>
+        </div>
+      )}
+
+      {/* Table view */}
+      {showTable && tableRows && <TableView rows={tableRows} columns={columns} />}
+
+      {/* Chart view */}
+      {showChart && chartSeries && <ChartView series={chartSeries} />}
+
       {/* JSON Viewer */}
+      {jsonView && (
       <div className="flex-1 overflow-auto scrollbar-hide">
         <pre className="font-mono text-xs leading-relaxed p-6">
           <ExpandContext.Provider value={{ expandSig, collapseSig, generation }}>
@@ -503,6 +941,7 @@ export function ResponsePanel({
           </div>
         )}
       </div>
+      )}
 
       {/* Suggested follow-ups */}
       {suggestedNext.length > 0 && (
@@ -522,5 +961,6 @@ export function ResponsePanel({
         </div>
       )}
     </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/playground/SmartParamInput.tsx
+++ b/src/components/playground/SmartParamInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { ParamDef } from './endpointCatalog';
 import { Switch } from '../branding/ui/switch';

--- a/src/components/playground/WebSocketPanel.tsx
+++ b/src/components/playground/WebSocketPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { WsEndpointDef } from './endpointCatalog';
 import { SmartParamInput } from './SmartParamInput';
@@ -120,7 +120,10 @@ export function WebSocketPanel({
       if (msg.type === 'ping') return;
 
       if (msg.type === 'initial') {
-        const initialBlocks = (msg.data as Array<Record<string, unknown>>).map((b) => ({
+        const rawInitial = Array.isArray(msg.data)
+          ? (msg.data as Array<Record<string, unknown>>)
+          : [];
+        const initialBlocks = rawInitial.map((b) => ({
           id: crypto.randomUUID(),
           receivedAt: Date.now(),
           chain_id: Number(b.chain_id ?? 0),

--- a/src/components/playground/endpointCatalog.ts
+++ b/src/components/playground/endpointCatalog.ts
@@ -113,16 +113,6 @@ export const REST_ENDPOINTS: EndpointDef[] = [
     params: [],
     suggestedNext: ['evm-blocks', 'metrics-chain-stats'],
   },
-  {
-    id: 'metrics-storage',
-    method: 'GET',
-    path: '/api/v1/metrics/storage',
-    title: 'Storage Stats',
-    description: 'Per-table on-disk size (bytes) and row counts for the indexer store',
-    category: 'Health & System',
-    params: [],
-  },
-
   // EVM Data
   {
     id: 'evm-blocks',
@@ -445,7 +435,16 @@ export const REST_ENDPOINTS: EndpointDef[] = [
     title: 'P-Chain Transaction Types',
     description: 'Get all P-Chain transaction types with counts',
     category: 'P-Chain Data',
-    params: [],
+    params: [
+      {
+        name: 'days',
+        kind: 'query',
+        type: 'int',
+        required: false,
+        default: '',
+        description: 'Restrict counts to the last N days (omit for all-time)',
+      },
+    ],
     suggestedNext: ['pchain-txs'],
   },
   {

--- a/src/components/playground/fieldHints.ts
+++ b/src/components/playground/fieldHints.ts
@@ -1,0 +1,115 @@
+// Short, plain-language descriptions for common response fields, sourced from
+// API.md. Field names are descriptive and consistent across endpoints, so a
+// flat name → hint map covers most cases. Used for hover tooltips in the
+// response panel; a missing key just means no tooltip.
+
+export const FIELD_HINTS: Record<string, string> = {
+  // Pagination / meta
+  limit: 'Max number of results in this page',
+  offset: 'Pagination offset',
+  has_more: 'Whether more results exist beyond this page',
+  next_cursor: 'Pass as ?cursor= to fetch the next page',
+  total: 'Total matching records (only when ?count=true)',
+  cursor: 'Keyset pagination cursor',
+
+  // Blocks
+  block_number: 'Block height',
+  block_time: 'Block timestamp (ISO 8601, UTC)',
+  block_hash: 'Block hash',
+  parent_hash: 'Hash of the previous block',
+  parent_id: 'Parent block ID',
+  miner: 'Block producer / coinbase address',
+  size: 'Block size in bytes',
+  gas_limit: 'Max gas allowed in the block',
+  gas_used: 'Gas actually consumed',
+  base_fee_per_gas: 'EIP-1559 base fee per gas (wei)',
+  tx_count: 'Number of transactions',
+  proposer_node_id: 'NodeID of the block proposer',
+  block_type: 'P-Chain block / tx type',
+
+  // Transactions
+  hash: 'Transaction hash',
+  transaction_index: 'Position of the tx within its block',
+  from: 'Sender address',
+  to: 'Recipient address (null for contract creation)',
+  value: 'Amount transferred (wei, string)',
+  gas_price: 'Gas price paid (wei)',
+  success: 'Whether the tx succeeded',
+  type: 'Tx type: 0 legacy, 1 EIP-2930, 2 EIP-1559, 3 EIP-4844',
+  call_type: 'Internal call type (CALL, DELEGATECALL, …)',
+  trace_index: 'Path of the call in the trace tree',
+  log_index: 'Index of the event log in the block',
+
+  // Tokens / balances / stablecoins
+  token: 'ERC-20 token contract address',
+  symbol: 'Token symbol',
+  name: 'Token name',
+  decimals: 'Token decimals (scale amounts by this)',
+  balance: 'Balance in the token smallest unit (string)',
+  total_in: 'Total received (smallest unit)',
+  total_out: 'Total sent (smallest unit)',
+  total_gas: 'Total gas spent (wei)',
+  peg: 'Currency the stablecoin is pegged to',
+  issuer: 'Stablecoin issuer',
+  bridged: 'Whether the token is bridged (vs native)',
+  supply: 'Circulating supply (smallest unit, string)',
+  holders: 'Number of holders',
+  volume_24h: '24h transfer volume (smallest unit)',
+  transfers_24h: '24h transfer count',
+  amount: 'Amount in nAVAX',
+  is_unlimited: 'Whether the approval is unlimited',
+
+  // P-Chain / subnets / chains
+  tx_id: 'P-Chain transaction ID (CB58)',
+  tx_type: 'P-Chain transaction type (no Tx suffix)',
+  subnet_id: 'Subnet ID (CB58)',
+  chain_id: 'Blockchain ID (CB58)',
+  evm_chain_id: 'EVM chain ID (numeric)',
+  chain_name: 'Chain name',
+  chain_type: 'l1 or legacy',
+  vm_id: 'Virtual machine ID',
+  sybil_resistance_type: 'Proof of Stake or Proof of Authority',
+  network_token: 'Native/gas token info',
+  network: 'mainnet or fuji',
+  validator_count: 'Total validators',
+  active_validators: 'Currently active validators',
+  total_staked: 'Sum of validator weights (raw)',
+  total_staked_tokens: 'Total staked in whole tokens (PoS only)',
+  total_fees_paid: 'All-time L1 validation fees (nAVAX)',
+  validator_manager_address: 'ValidatorManager contract address',
+
+  // Validators
+  node_id: 'Validator NodeID',
+  validation_id: 'Validation ID (CB58)',
+  weight: 'Validator weight (P-Chain uint64)',
+  staked_amount: 'Stake in whole tokens (PoS only, string)',
+  staked_token: 'Symbol of the staked token (PoS only)',
+  uptime_percentage: 'Validator uptime (%)',
+  active: 'Whether the validator is active',
+  start_time: 'Validation start time',
+  end_time: 'Validation end time (omitted for L1 validators)',
+  initial_deposit: 'Initial balance deposit (nAVAX)',
+  total_topups: 'Total balance top-ups (nAVAX)',
+  remaining_balance: 'Continuous-fee balance left (nAVAX)',
+  fees_paid: 'Validation fees paid so far (nAVAX)',
+  days_remaining: 'Days until the balance runs out',
+  network_share_percent: "Validator weight as % of the subnet total",
+  bls_public_key: 'Validator BLS public key',
+
+  // Metrics / timeseries / fee burn
+  metric_name: 'Metric identifier',
+  granularity: 'Time bucket: hour, day, week, or month',
+  period: 'Start of the time bucket',
+  unit: 'Unit of the amounts (e.g. nAVAX)',
+  total_burned: 'Total fee burned in the period (nAVAX)',
+  base_fee_burned: 'Base-fee portion burned (nAVAX)',
+  priority_fee_burned: 'Priority-tip portion burned (nAVAX)',
+  cumulative: 'All-time cumulative totals',
+  nakamoto_33: 'Min validators controlling >33% of weight',
+  nakamoto_50: 'Min validators controlling >50% of weight',
+  total_weight: 'Total active validator weight',
+};
+
+export function fieldHint(key: string): string | undefined {
+  return FIELD_HINTS[key];
+}

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { ToasterProvider } from './components/Toaster';
 import App from './App';
 
-export function render(url: string, context: any) {
+export function render(url: string, _context: any) {
   const helmetContext: any = {};
   
   const html = ReactDOMServer.renderToString(

--- a/src/pages/ACPDetails.tsx
+++ b/src/pages/ACPDetails.tsx
@@ -12,9 +12,7 @@ import { SEO } from '../components/SEO';
 import {
   ArrowLeft,
   ArrowUpCircle,
-  ExternalLink,
   Users,
-  Tag,
   Clock,
   Github,
   Link as LinkIcon,
@@ -25,10 +23,10 @@ import {
   XCircle,
   AlertTriangle,
   RefreshCw,
-  BookOpen,
   Info
 } from 'lucide-react';
-import { acpService, LocalACP } from '../services/acpService';
+import { acpService } from '../services/acpService';
+import type { Author, EnhancedACP } from '../types';
 
 // Lazy-load mermaid (and its diagram renderers + cytoscape) only when an ACP
 // actually contains a diagram. Keeps ~1MB+ out of the main bundle for every
@@ -98,11 +96,11 @@ const preprocessContent = (content: string) => {
     .replace(/\$AVAX-([A-Za-z][A-Za-z\-]*)/g, '&#36;AVAX-$1')
     .replace(/\$ETH(?!\s*[+\-*/=<>≥≤\\{}()^_])/g, '&#36;ETH')
     .replace(/\$ETH-([A-Za-z][A-Za-z\-]*)/g, '&#36;ETH-$1')
-    .replace(/\n*\[!NOTE\]\s*(.*?)(?=\n\n|\n(?=[A-Z])|$)/gs, (match, noteContent) => {
+    .replace(/\n*\[!NOTE\]\s*(.*?)(?=\n\n|\n(?=[A-Z])|$)/gs, (_match, noteContent) => {
       return `\n\n:::note\n${noteContent.trim()}\n\n\n`;
     })
     // Convert [WARNING] blocks if they exist
-    .replace(/\n*\[!WARNING\]\s*(.*?)(?=\n\n|\n(?=[A-Z])|$)/gs, (match, warningContent) => {
+    .replace(/\n*\[!WARNING\]\s*(.*?)(?=\n\n|\n(?=[A-Z])|$)/gs, (_match, warningContent) => {
       return `\n\n:::warning\n${warningContent.trim()}\n\n\n`;
     })
     .replace(/<div[^>]*>/g, '')
@@ -112,7 +110,7 @@ const preprocessContent = (content: string) => {
 export default function ACPDetails() {
   const { acpNumber } = useParams<{ acpNumber: string }>();
   const navigate = useNavigate();
-  const [acp, setAcp] = useState<LocalACP | null>(null);
+  const [acp, setAcp] = useState<EnhancedACP | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -238,100 +236,7 @@ export default function ACPDetails() {
     // Get current theme
     const { theme } = useTheme();
     const isDark = theme === 'dark';
-    
-    // Improved theme variables that match your app's design system
-    const getDarkThemeVariables = () => ({
-      // Primary elements - nice blue that matches your app
-      primaryColor: '#3b82f6',
-      primaryTextColor: '#e2e8f0',  // Light gray for better readability
-      primaryBorderColor: '#1e40af',
-      
-      // Lines and connections
-      lineColor: '#64748b',         // Neutral gray for lines
-      
-      // Background colors using your dark palette
-      background: '#0f172a',        // dark-900
-      mainBkg: '#1e293b',          // dark-800  
-      secondBkg: '#334155',        // dark-700
-      tertiaryColor: '#475569',    // dark-600
-      
-      // Secondary elements
-      secondaryColor: '#334155',    // dark-700
-      
-      // Additional colors for better contrast
-      cScale0: '#0f172a',          // dark-900
-      cScale1: '#1e293b',          // dark-800
-      cScale2: '#334155',          // dark-700
-      cScale3: '#475569',          // dark-600
-      cScale4: '#64748b',          // dark-500
-      
-      // Text colors with good contrast
-      cScale11: '#e2e8f0',         // Light text
-      cScale12: '#f1f5f9',         // Lighter text
-      
-      // Node specific colors
-      nodeBkg: '#1e293b',          // dark-800
-      nodeTextColor: '#e2e8f0',    // Light gray
-      nodeBorder: '#3b82f6',       // Blue border
-      
-      // Special element colors
-      clusterBkg: '#334155',       // dark-700
-      clusterBorder: '#64748b',    // dark-500
-      defaultLinkColor: '#64748b', // dark-500
-      
-      // Error and success states
-      errorBkgColor: '#ef4444',
-      errorTextColor: '#fecaca',
-      successBkgColor: '#10b981',
-      successTextColor: '#a7f3d0',
-    });
 
-    const getLightThemeVariables = () => ({
-      // Primary elements - matching blue
-      primaryColor: '#3b82f6',
-      primaryTextColor: '#1e293b',  // Dark text for contrast
-      primaryBorderColor: '#1e40af',
-      
-      // Lines and connections  
-      lineColor: '#64748b',         // Neutral gray
-      
-      // Light backgrounds
-      background: '#ffffff',
-      mainBkg: '#ffffff',
-      secondBkg: '#f8fafc',        // Very light gray
-      tertiaryColor: '#e2e8f0',    // Light gray
-      
-      // Secondary elements
-      secondaryColor: '#f1f5f9',   // Light gray
-      
-      // Scale colors for light mode
-      cScale0: '#ffffff',
-      cScale1: '#f8fafc',
-      cScale2: '#f1f5f9',
-      cScale3: '#e2e8f0',
-      cScale4: '#cbd5e1',
-      
-      // Dark text for contrast
-      cScale11: '#334155',
-      cScale12: '#1e293b',
-      
-      // Node colors for light mode
-      nodeBkg: '#ffffff',
-      nodeTextColor: '#1e293b',
-      nodeBorder: '#3b82f6',
-      
-      // Special elements
-      clusterBkg: '#f8fafc',
-      clusterBorder: '#cbd5e1',
-      defaultLinkColor: '#64748b',
-      
-      // States
-      errorBkgColor: '#ef4444',
-      errorTextColor: '#991b1b',
-      successBkgColor: '#10b981',
-      successTextColor: '#065f46',
-    });
-    
     // Check if this is a mermaid diagram
     const isMermaid = language === 'mermaid' || 
                     content.includes('flowchart') || 
@@ -588,10 +493,6 @@ export default function ACPDetails() {
 
   const githubUrl = `https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/${acp.folderName || acp.number}/README.md`;
 
-  const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>, url: string) => {
-    window.open(url, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div className="bg-background text-foreground">
       <SEO
@@ -652,7 +553,7 @@ export default function ACPDetails() {
                   <div className="flex items-center gap-2">
                     <Users className="w-5 h-5 text-muted-foreground" />
                     <div className="flex flex-wrap items-center gap-2">
-                      {acp.authors?.map((author, index) => (
+                      {acp.authors?.map((author: Author, index: number) => (
                         <React.Fragment key={index}>
                           {index > 0 && <span className="text-muted-foreground">|</span>}
                           <a

--- a/src/pages/ACPs.tsx
+++ b/src/pages/ACPs.tsx
@@ -1,15 +1,12 @@
 // src/pages/ACPs.tsx
-import React, { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { SEO } from '../components/SEO';
 import {
   FileText,
-  ExternalLink,
   CheckCircle,
-  Clock,
-  XCircle,
   RefreshCw,
   AlertTriangle,
   Search,
@@ -18,15 +15,10 @@ import {
   List,
   TrendingUp,
   Users,
-  Tag,
-  BookOpen,
-  ChevronDown,
-  Star,
-  Archive,
-  Code,
-  AlertCircle
+  Archive
 } from 'lucide-react';
-import { acpService, LocalACP, EnhancedACP, ACPStats } from '../services/acpService';
+import { acpService } from '../services/acpService';
+import type { EnhancedACP, ACPStats } from '../types';
 import EnhancedACPCard from '../components/ACPCard';
 
 
@@ -39,11 +31,12 @@ interface Filters {
   track: string;
   complexity: string;
   author: string;
+  hasDiscussion?: boolean | null;
 }
 
 export default function ACPs() {
   const navigate = useNavigate();
-  const [acps, setAcps] = useState<LocalACP[]>([]);
+  const [acps, setAcps] = useState<EnhancedACP[]>([]);
   const [stats, setStats] = useState<ACPStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,8 +44,8 @@ export default function ACPs() {
   // UI State
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<SortOption>('number');
-  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [sortBy] = useState<SortOption>('number');
+  const [sortOrder] = useState<SortOrder>('desc');
   const [showFilters, setShowFilters] = useState(false);
 
   // Filters
@@ -113,7 +106,10 @@ export default function ACPs() {
   };
 
     function calculateStats(acps: EnhancedACP[]): ACPStats {
-  const stats: ACPStats = {
+  // These optional ACPStats fields are all initialized below and mutated in the
+  // loop, so require them locally to keep index writes and increments well-typed.
+  const stats: ACPStats &
+    Required<Pick<ACPStats, 'byCategory' | 'byImpact' | 'implementationProgress' | 'recentlyUpdated' | 'needsAttention'>> = {
     total: acps.length,
     byStatus: {},
     byTrack: {},
@@ -248,64 +244,6 @@ export default function ACPs() {
 
     return filtered;
   }, [acps, searchQuery, filters, sortBy, sortOrder]);
-
-  const getStatusIcon = (status: string) => {
-    const cleanStatus = getCleanStatus(status); 
-    switch (cleanStatus?.toLowerCase()) {
-      case 'final':
-      case 'active':
-      case 'activated':
-        return <CheckCircle className="w-4 h-4 text-white" />;
-      case 'draft':
-      case 'proposed':
-        return <Clock className="w-4 h-4 text-white" />;
-      case 'review':
-        return <AlertCircle className="w-4 h-4 text-white" />;
-      case 'withdrawn':
-      case 'rejected':
-      case 'stagnant':
-      case 'stale':
-        return <XCircle className="w-4 h-4 text-white" />;
-      default:
-        return <AlertTriangle className="w-4 h-4 text-white" />;
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    const cleanStatus = getCleanStatus(status);
-    switch (cleanStatus?.toLowerCase()) {
-      case 'final':
-      case 'active':
-      case 'activated':
-        return 'bg-green-500 text-white';
-      case 'draft':
-      case 'proposed':
-        return 'bg-[#ef4444] text-white';
-      case 'review':
-        return 'bg-yellow-500 text-white';
-      case 'withdrawn':
-      case 'rejected':
-      case 'stagnant':
-      case 'stale':
-        return 'bg-muted text-foreground border border-border';
-      default:
-        return 'bg-muted text-foreground border border-border';
-    }
-  };
-
-  const getComplexityColor = (complexity: string) => {
-    switch (complexity) {
-      case 'Low':
-        return 'bg-[#ef4444]/10 text-[#ef4444] dark:bg-[#ef4444]/20 dark:text-[#ef4444]';
-      case 'Medium':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-500/20 dark:text-yellow-400';
-      case 'High':
-        return 'bg-red-100 text-red-800 dark:bg-red-500/20 dark:text-red-400';
-      default:
-        // Avoid bg-muted/xx opacity: CSS vars are not RGB, can break in dark mode.
-        return 'bg-muted text-muted-foreground border border-border';
-    }
-  };
 
   const clearFilters = () => {
     setFilters({

--- a/src/pages/APIPlayground.tsx
+++ b/src/pages/APIPlayground.tsx
@@ -27,6 +27,9 @@ const HISTORY_STORAGE_KEY = 'l1beat_playground_history';
 const BOOKMARKS_STORAGE_KEY = 'l1beat_playground_bookmarks';
 const MAX_HISTORY = 20;
 const CARRY_OVER_PARAMS = ['chainId', 'limit', 'offset', 'subnet_id'];
+// Upper bound on rows accumulated via "Load more" — keeps memory and the JSON
+// viewer bounded on endpoints with huge result sets.
+const MAX_CUMULATIVE_ROWS = 1000;
 
 function loadBookmarks(): Bookmark[] {
   try {
@@ -162,6 +165,17 @@ function buildCurl(url: string): string {
   return `curl "${url}"`;
 }
 
+// Collect the response headers JS can read. Cross-origin, the browser only
+// exposes the CORS-safelisted ones (cache-control, content-type, …) unless the
+// server sends Access-Control-Expose-Headers.
+function readHeaders(h: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  h.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
+
 function buildFetchSnippet(url: string): string {
   return `const res = await fetch('${url}');
 const data = await res.json();
@@ -225,6 +239,7 @@ export function APIPlayground() {
   const [cumulativeData, setCumulativeData] = useState<unknown[]>([]);
   const [status, setStatus] = useState<number | null>(null);
   const [durationMs, setDurationMs] = useState<number | null>(null);
+  const [responseHeaders, setResponseHeaders] = useState<Record<string, string> | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>(loadHistory);
@@ -313,7 +328,7 @@ export function APIPlayground() {
       setParams(newParams);
       setResponse(null);
       setCumulativeData([]);
-      setStatus(null);
+      setStatus(null); setResponseHeaders(null);
       setDurationMs(null);
       setNetworkError(null);
       setMobileTab('request');
@@ -343,11 +358,11 @@ export function APIPlayground() {
       setNetworkError(null);
       setResponse(null);
       setCumulativeData([]);
-      setStatus(null);
+      setStatus(null); setResponseHeaders(null);
 
       const startTime = performance.now();
       try {
-        const res = await fetch(url);
+        const res = await fetch(url, { cache: 'no-store' });
         const elapsed = Math.round(performance.now() - startTime);
         let json: unknown = null;
         try {
@@ -360,7 +375,7 @@ export function APIPlayground() {
           : [];
         setCumulativeData(freshData);
         setResponse(json);
-        setStatus(res.status);
+        setStatus(res.status); setResponseHeaders(readHeaders(res.headers));
         setDurationMs(elapsed);
         const entry: HistoryEntry = {
           id: crypto.randomUUID(),
@@ -414,7 +429,7 @@ export function APIPlayground() {
       setSelectedId(endpointId);
       setParams(merged);
       setResponse(null);
-      setStatus(null);
+      setStatus(null); setResponseHeaders(null);
       setDurationMs(null);
       setNetworkError(null);
       setMobileTab('request');
@@ -426,7 +441,7 @@ export function APIPlayground() {
           const url = buildUrl(restEndpoint.path, merged);
           setIsLoading(true);
           const startTime = performance.now();
-          fetch(url)
+          fetch(url, { cache: 'no-store' })
             .then(async (res) => {
               const elapsed = Math.round(performance.now() - startTime);
               let json: unknown = null;
@@ -436,7 +451,7 @@ export function APIPlayground() {
                 : [];
               setCumulativeData(freshData);
               setResponse(json);
-              setStatus(res.status);
+              setStatus(res.status); setResponseHeaders(readHeaders(res.headers));
               setDurationMs(elapsed);
               const entry: HistoryEntry = { id: crypto.randomUUID(), endpointId, url, status: res.status, durationMs: elapsed, timestamp: Date.now(), response: json };
               setHistory((prev) => { const next = [entry, ...prev].slice(0, MAX_HISTORY); saveHistory(next); return next; });
@@ -469,7 +484,7 @@ export function APIPlayground() {
       setParams(buildDefaults(endpoint));
     }
     setResponse(entry.response);
-    setStatus(entry.status);
+    setStatus(entry.status); setResponseHeaders(null);
     setDurationMs(entry.durationMs);
     setNetworkError(null);
   }, []);
@@ -482,6 +497,7 @@ export function APIPlayground() {
   const handleLoadNextPage = useCallback(async () => {
     if (!selectedId || isWsEndpoint(selectedId)) return;
     if (isLoading) return;
+    if (cumulativeData.length >= MAX_CUMULATIVE_ROWS) return;
     const endpoint = REST_ENDPOINTS.find((e) => e.id === selectedId);
     if (!endpoint) return;
     const meta = (response as Record<string, unknown>)?.meta as Record<string, unknown> | undefined;
@@ -502,7 +518,7 @@ export function APIPlayground() {
     setIsLoading(true);
     const startTime = performance.now();
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { cache: 'no-store' });
       const elapsed = Math.round(performance.now() - startTime);
       let json: unknown = null;
       try { json = await res.json(); } catch { json = { error: { message: 'Response body was not valid JSON' } }; }
@@ -511,7 +527,7 @@ export function APIPlayground() {
         : [];
       setCumulativeData((prev) => [...prev, ...newItems]);
       setResponse(json);
-      setStatus(res.status);
+      setStatus(res.status); setResponseHeaders(readHeaders(res.headers));
       setDurationMs(elapsed);
     } catch (err) {
       const elapsed = Math.round(performance.now() - startTime);
@@ -520,11 +536,23 @@ export function APIPlayground() {
     } finally {
       setIsLoading(false);
     }
-  }, [response, params, selectedId, isLoading]);
+  }, [response, params, selectedId, isLoading, cumulativeData.length]);
 
   const handleRetryAfter = useCallback(() => {
     handleExecute();
   }, [handleExecute]);
+
+  // Build a shareable link from current state at click time, so it never lags
+  // behind the debounced address-bar sync.
+  const getShareUrl = useCallback(() => {
+    const sp = new URLSearchParams();
+    if (selectedId) sp.set('endpoint', selectedId);
+    Object.entries(params).forEach(([k, v]) => {
+      if (v && v !== '') sp.set(k, v);
+    });
+    sp.set('autorun', '1');
+    return `${window.location.origin}${window.location.pathname}?${sp.toString()}`;
+  }, [selectedId, params]);
 
   // Bookmark handlers — strip ephemeral pagination keys before comparing
   const EPHEMERAL_PARAMS = ['cursor', 'offset'];
@@ -582,7 +610,7 @@ export function APIPlayground() {
     setParams(bm.params);
     setResponse(null);
     setCumulativeData([]);
-    setStatus(null);
+    setStatus(null); setResponseHeaders(null);
     setDurationMs(null);
     setNetworkError(null);
     setMobileTab('request');
@@ -610,8 +638,9 @@ export function APIPlayground() {
   const responseMeta = response
     ? ((response as Record<string, unknown>)?.meta as Record<string, unknown> | undefined)
     : undefined;
-  const hasNextPage = Boolean(responseMeta?.next_cursor) ||
-    (Boolean(responseMeta?.has_more) && !responseMeta?.next_cursor);
+  const hasNextPage = (Boolean(responseMeta?.next_cursor) ||
+    (Boolean(responseMeta?.has_more) && !responseMeta?.next_cursor)) &&
+    cumulativeData.length < MAX_CUMULATIVE_ROWS;
 
   const wsEndpoint = selectedId ? WS_ENDPOINTS.find((e) => e.id === selectedId) : undefined;
 
@@ -740,12 +769,14 @@ export function APIPlayground() {
                       response={displayResponse}
                       status={status}
                       durationMs={durationMs}
+                      headers={responseHeaders}
                       networkError={networkError}
                       isLoading={isLoading}
                       onLoadNextPage={hasNextPage ? handleLoadNextPage : null}
                       suggestedNext={suggestedNext}
                       onSuggestSelect={handleEndpointSelect}
                       onRetryAfter={handleRetryAfter}
+                      getShareUrl={getShareUrl}
                     />
                   </div>
                 </div>
@@ -841,12 +872,14 @@ export function APIPlayground() {
                       response={displayResponse}
                       status={status}
                       durationMs={durationMs}
+                      headers={responseHeaders}
                       networkError={networkError}
                       isLoading={isLoading}
                       onLoadNextPage={hasNextPage ? handleLoadNextPage : null}
                       suggestedNext={suggestedNext}
                       onSuggestSelect={handleEndpointSelect}
                       onRetryAfter={handleRetryAfter}
+                      getShareUrl={getShareUrl}
                     />
                   </div>
                 )}

--- a/src/pages/ChainDetails.tsx
+++ b/src/pages/ChainDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useParams, useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
-import { getChains, getTPSHistory, getChainValidators, getChainRisk, getL1BeatValidators, getL1BeatSubnetType, getL1BeatDailyFeeBurn, getL1BeatFeeMetrics, getEvmFeesBurned, DailyFeeBurn } from '../api';
+import { getChains, getTPSHistory, getChainRisk, getL1BeatValidators, getL1BeatSubnetType, getL1BeatDailyFeeBurn, getL1BeatFeeMetrics, getEvmFeesBurned, DailyFeeBurn } from '../api';
 import { Chain, TPSHistory, ChainRisk } from '../types';
 import {
   Activity,
@@ -23,12 +23,11 @@ import {
 } from 'lucide-react';
 import { Line, Bar } from 'react-chartjs-2';
 import { watermarkPlugin, smoothLinePath } from '../utils/chartConfig';
-import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, BarElement, Filler, Tooltip as ChartTooltip, Legend as ChartLegend } from 'chart.js';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, BarElement, Filler, Tooltip as ChartTooltip, Legend as ChartLegend, TooltipItem } from 'chart.js';
 import { StakeDistributionChart, getValidatorColor } from '../components/StakeDistributionChart';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Filler, ChartTooltip, ChartLegend);
 import { AddToMetaMask } from '../components/AddToMetaMask';
-import { LoadingSpinner } from '../components/LoadingSpinner';
 import { SEO } from '../components/SEO';
 import { SectionErrorBoundary } from '../components/SectionErrorBoundary';
 import { ChartWatermark } from '../components/ChartWatermark';
@@ -288,7 +287,7 @@ export function ChainDetails() {
         // If uptime is missing for this chain, fall back to remainingBalance (if present).
         // Note: we treat 0 as a valid numeric value; missing is undefined/null/non-finite.
         if (chain?.validators?.some(v => Number.isFinite(v.uptime))) {
-          comparison = (Number.isFinite(a.uptime) ? a.uptime : -1) - (Number.isFinite(b.uptime) ? b.uptime : -1);
+          comparison = (Number.isFinite(a.uptime) ? (a.uptime as number) : -1) - (Number.isFinite(b.uptime) ? (b.uptime as number) : -1);
         } else {
           const aBal = (a.remainingBalance ?? 0);
           const bBal = (b.remainingBalance ?? 0);
@@ -317,7 +316,7 @@ export function ChainDetails() {
   // Legacy subnets (primary network) use staking — show uptime column.
   const isL1Subnet = subnetType === 'l1';
   const hasRemainingBalanceData = isL1Subnet && (chain?.validators?.some(v => Number.isFinite(v.remainingBalance)) ?? false);
-  const hasUptimeData = !hasRemainingBalanceData && (chain?.validators?.some(v => Number.isFinite(v.uptime) && v.uptime > 0) ?? false);
+  const hasUptimeData = !hasRemainingBalanceData && (chain?.validators?.some(v => Number.isFinite(v.uptime) && (v.uptime as number) > 0) ?? false);
 
   const sybilResistance = (chain?.sybilResistanceType || '').toLowerCase();
 
@@ -1368,7 +1367,7 @@ export function ChainDetails() {
                                       (validator.uptime || 0) >= 90 ? 'text-green-600 dark:text-green-400' :
                                       (validator.uptime || 0) >= 80 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'
                                     }`}>
-                                        {Number.isFinite(validator.uptime) ? `${validator.uptime.toFixed(1)}%` : 'N/A'}
+                                        {Number.isFinite(validator.uptime) ? `${(validator.uptime as number).toFixed(1)}%` : 'N/A'}
                                     </span>
                                   </div>
                                   ) : (
@@ -1578,11 +1577,13 @@ function CChainBurnBreakdownChart({ daily, monthly, isDark }: {
                   borderWidth: 1,
                   padding: 12,
                   callbacks: {
-                    label: (ctx: { dataset: { label?: string }; dataIndex: number; parsed: { y: number } }) => {
+                    label: (ctx: TooltipItem<'bar'>) => {
                       const d = series[ctx.dataIndex];
                       const total = d.base + d.priority;
-                      const pct = total > 0 ? (ctx.parsed.y / total) * 100 : 0;
-                      return `${ctx.dataset.label}: ${formatAvaxAmount(ctx.parsed.y)} AVAX (${pct.toFixed(1)}%)`;
+                      // Bar values are always numeric here; chart.js types y as number | null.
+                      const y = ctx.parsed.y as number;
+                      const pct = total > 0 ? (y / total) * 100 : 0;
+                      return `${ctx.dataset.label}: ${formatAvaxAmount(y)} AVAX (${pct.toFixed(1)}%)`;
                     },
                     footer: (items: { dataIndex: number }[]) => {
                       const d = series[items[0].dataIndex];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -562,7 +562,9 @@ export function Dashboard() {
         selectedCategory={selectedCategory}
         onCategoryChange={setSelectedCategory}
         categories={categories}
-        validatorFilter={validatorFilter}
+        // The modal only offers active/all/inactive; when the tab is 'watchlist'
+        // it simply renders with nothing selected. Narrow cast preserves that.
+        validatorFilter={validatorFilter as 'active' | 'all' | 'inactive'}
         onValidatorFilterChange={setValidatorFilter}
       />
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FileQuestion, ArrowLeft } from 'lucide-react';
 import { ThemeToggle } from '../components/ThemeToggle';

--- a/src/pages/Stablecoins.tsx
+++ b/src/pages/Stablecoins.tsx
@@ -1571,23 +1571,27 @@ function SupplyTreemap({
   const H = 320;
 
   const rects = useMemo(() => {
+    // Recursive datum type so children match the node datum type.
+    type TreemapDatum = { children?: TreemapDatum[]; coin?: EnrichedCoin };
     const filtered = coins.filter((c) => c.supplyUsd > 0);
     if (filtered.length === 0) return [];
     const root = d3
-      .hierarchy<{ children?: EnrichedCoin[]; coin?: EnrichedCoin }>({
+      .hierarchy<TreemapDatum>({
         children: filtered.map((c) => ({ coin: c })),
       })
       .sum((d) => (d.coin ? d.coin.supplyUsd : 0))
       .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 
     d3
-      .treemap<{ children?: EnrichedCoin[]; coin?: EnrichedCoin }>()
+      .treemap<TreemapDatum>()
       .size([W, H])
       .padding(2)
       .round(true)
       .tile(d3.treemapSquarify)(root);
 
-    return root.leaves().map((leaf) => {
+    return root.leaves().map((node) => {
+      // treemap() lays out nodes, so they carry x0/y0/x1/y1 coordinates.
+      const leaf = node as d3.HierarchyRectangularNode<TreemapDatum>;
       const coin = leaf.data.coin!;
       const x = leaf.x0;
       const y = leaf.y0;

--- a/src/utils/chartConfig.ts
+++ b/src/utils/chartConfig.ts
@@ -8,7 +8,6 @@ import {
   Tooltip,
   Legend,
   Filler,
-  ChartOptions,
   Plugin
 } from 'chart.js';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,7 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export default defineConfig(async ({ mode }) => {
+export default defineConfig(async ({ mode }): Promise<UserConfig> => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), '');
   const apiBaseUrl = env.VITE_API_BASE_URL;


### PR DESCRIPTION
## Summary
Introduces the public L1Beat API playground and hardens the app for launch, and restores real typechecking in the build.

### Playground (/api)
- Chart and table views for responses; the chart has a hover tooltip and the shared L1Beat watermark
- Response headers panel, inline field hints, validator ID links, rate-limit quota chip
- Cache-bypass so re-runs hit the live API; removed the operator-only storage endpoint from the catalog
- Launch hardening: the 429 auto-retry is capped with a manual fallback, large responses are render-capped so they cannot freeze the tab, and share links are built from live state (race-free)

### Navigation
- API entry enabled in the sidebar, mobile dock, and command palette (was "coming soon")

### UI fix
- Select and Tooltip dropdowns now scroll. They used Tailwind v4 arbitrary-value syntax that does not compile under this project's Tailwind v3, so long dropdowns (e.g. the metric picker) overflowed the viewport with no scroll

### Build / type safety
- Build now runs `tsc -b` so typechecking actually gates it. Plain `tsc` was a no-op because the solution-style tsconfig has empty `files`
- Fixed the ~109 pre-existing type errors this surfaced across the app
- Ignored `*.tsbuildinfo`

## Verification
- `tsc -b` passes (0 errors)
- `vite build` passes
- Live API smoke-tested; chart pipeline verified against real timeseries responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
